### PR TITLE
CODE_OF_CONDUCT: Use private e-mail for reporting.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ a project may be further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at mptcp@lists.01.org. All
+reported by contacting the project team at mptcp-owner@lists.01.org. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.


### PR DESCRIPTION
Do not use the public mptcp@lists.01.org mailing list for handling of Code of Conduct related reports.  Use the private mptcp-owner@lists.01.org instead.