### PR TITLE
Fix errors under clang build.

### DIFF
--- a/tests/test-path-manager.c
+++ b/tests/test-path-manager.c
@@ -116,7 +116,7 @@ int main(void)
 
         static int argc = L_ARRAY_SIZE(argv);
 
-        struct test_info info = { NULL };
+        struct test_info info = { .config = NULL };
 
         info.config = mptcpd_config_create(argc, argv);
         assert(info.config);

--- a/tests/test-plugin.h
+++ b/tests/test-plugin.h
@@ -251,7 +251,7 @@ struct mptcpd_addr const test_raddr_4 = {
 /**
  * @brief Compare equality of two @c mptcpd_addr objects.
  */
-inline bool mptcpd_addr_is_equal(struct mptcpd_addr const *lhs,
+extern bool mptcpd_addr_is_equal(struct mptcpd_addr const *lhs,
                                  struct mptcpd_addr const *rhs)
 {
         if (lhs->address.family == rhs->address.family
@@ -275,7 +275,7 @@ inline bool mptcpd_addr_is_equal(struct mptcpd_addr const *lhs,
         return false;
 }
 
-inline void call_plugin_ops(struct plugin_call_count const *count,
+extern void call_plugin_ops(struct plugin_call_count const *count,
                             char const *name,
                             mptcpd_cid_t connection_id,
                             mptcpd_aid_t laddr_id,


### PR DESCRIPTION
Building mptcpd with [clang](http://clang.llvm.org/) resulted in link- and compile-time errors in the `mptcpd/tests` directory.  This set of changes address those errors.  Fixes #7.
