### PR TITLE
Make clang-format configuration compatible with versions after 6.0.0

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -88,10 +88,6 @@ PenaltyBreakString: 1000
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Right
-RawStringFormats:
-  - Delimiter:       pb
-    Language:        TextProto
-    BasedOnStyle:    google
 ReflowComments:  true
 SortIncludes:    false
 SortUsingDeclarations: true


### PR DESCRIPTION
The RawStringFormats configuration value changed in structure after
version 6 of clang-format. Since the values were defaults, removing the
block from .clang-format keeps the same behavior but maintains
compatibility with various tool versions.