### PR TITLE
Correct genl API attribute mismatches.

### DIFF
--- a/lib/path_manager.c
+++ b/lib/path_manager.c
@@ -226,7 +226,7 @@ bool mptcpd_pm_add_subflow(struct mptcpd_pm *pm,
                               get_addr_size(&remote_addr->address))
                       + NLA_HDRLEN
                       + NLA_ALIGN(sizeof(remote_addr->port))))
-                + (backup ? NLA_HDRLEN : 0);
+                + NLA_HDRLEN + NLA_ALIGN(sizeof(backup));
 
         struct l_genl_msg *const msg =
                 l_genl_msg_new_sized(MPTCP_CMD_SUB_CREATE, payload_size);
@@ -265,11 +265,10 @@ bool mptcpd_pm_add_subflow(struct mptcpd_pm *pm,
                                                   MPTCP_ATTR_DPORT,
                                                   sizeof(remote_addr->port),
                                                   &remote_addr->port)))
-                && (!backup
-                    || l_genl_msg_append_attr(msg,
-                                              MPTCP_ATTR_BACKUP,
-                                              0,
-                                              NULL));  // NLA_FLAG
+                && l_genl_msg_append_attr(msg,
+                                          MPTCP_ATTR_BACKUP,
+                                          sizeof(backup),
+                                          &backup);
 
         if (!appended) {
                 l_genl_msg_unref(msg);
@@ -319,7 +318,7 @@ bool mptcpd_pm_set_backup(struct mptcpd_pm *pm,
                 + NLA_HDRLEN + NLA_ALIGN(
                         get_addr_size(&remote_addr->address))
                 + NLA_HDRLEN + NLA_ALIGN(sizeof(remote_addr->port))
-                + (backup ? NLA_HDRLEN : 0);
+                + NLA_HDRLEN + NLA_ALIGN(sizeof(backup));
 
         struct l_genl_msg *const msg =
                 l_genl_msg_new_sized(MPTCP_CMD_SUB_PRIORITY,
@@ -351,11 +350,10 @@ bool mptcpd_pm_set_backup(struct mptcpd_pm *pm,
                                           MPTCP_ATTR_DPORT,
                                           sizeof(remote_addr->port),
                                           &remote_addr->port)
-                && (!backup
-                    || l_genl_msg_append_attr(msg,
-                                              MPTCP_ATTR_BACKUP,
-                                              0,
-                                              NULL));  // NLA_FLAG
+                && l_genl_msg_append_attr(msg,
+                                          MPTCP_ATTR_BACKUP,
+                                          sizeof(backup),
+                                          &backup);
 
         if (!appended) {
                 l_genl_msg_unref(msg);
@@ -395,7 +393,7 @@ bool mptcpd_pm_remove_subflow(struct mptcpd_pm *pm,
          *       quite right.
          */
         size_t const payload_size =
-                NLA_HDRLEN + NLA_ALIGN(sizeof(token)) 
+                NLA_HDRLEN + NLA_ALIGN(sizeof(token))
                 + NLA_HDRLEN + NLA_ALIGN(sizeof(local_addr->address.family))
                 + NLA_HDRLEN + NLA_ALIGN(
                         get_addr_size(&local_addr->address))

--- a/plugins/path_managers/sspi.c
+++ b/plugins/path_managers/sspi.c
@@ -98,13 +98,13 @@ struct sspi_new_connection_info
  * @c mptcpd_in_addr) matches if its @c family and @c addr members
  * match those in the @a b.
  *
- * @return @c true if the network address represented by @a a matches
- *         the user supplied address @a b, and @c false
- *         otherwise.
+ * @param[in] a Currently monitored network address of type @c struct
+ *              @c mptcpd_in_addr*.
+ * @param[in] b Network address of type @c struct @c mptcpd_in_addr*
+ *              to be compared against network address @a a.
  *
- * @todo This is a copy of the private @c mptcpd_in_addr_match()
- *       function.  Consider refactoring, and exposing that function
- *       through the mptcpd_nm API.
+ * @return @c true if the network address represented by @a a matches
+ *         the address @a b, and @c false otherwise.
  *
  * @see l_queue_find()
  * @see l_queue_remove_if()
@@ -117,7 +117,6 @@ static bool sspi_in_addr_match(void const *a, void const *b)
         assert(lhs);
         assert(rhs);
         assert(lhs->family == AF_INET || lhs->family == AF_INET6);
-        assert(rhs->family == AF_INET || rhs->family == AF_INET6);
 
         bool matched = lhs->family == rhs->family;
 
@@ -195,6 +194,13 @@ static void sspi_get_index(struct mptcpd_interface const *interface,
         struct sspi_nm_callback_data *const callback_data = data;
 
         /*
+          Check if the network interface index was found during an
+          earlier iteration.
+        */
+        if (callback_data->index != SSPI_BAD_INDEX)
+                return;
+
+        /*
           Iterate through the network interface IP address list to
           determine which of them corresponds to the given IP address.
         */
@@ -227,6 +233,8 @@ static bool sspi_addr_to_index(struct mptcpd_nm const *nm,
                                struct mptcpd_addr const *addr,
                                int *index)
 {
+        assert(index != NULL);
+
         struct sspi_nm_callback_data data = {
                 .addr = addr,
                 .index = SSPI_BAD_INDEX
@@ -364,12 +372,10 @@ static struct sspi_interface_info *sspi_interface_info_lookup(
                                     NULL)) {
                         sspi_interface_info_destroy(info);
                         info = NULL;
-
-
                 }
         }
 
-        return NULL;
+        return info;
 }
 
 // ----------------------------------------------------------------

--- a/src/path_manager.c
+++ b/src/path_manager.c
@@ -503,7 +503,7 @@ static void handle_addr_removed(struct l_genl_msg *msg, void *user_data)
  * @return @c true on success, @c false otherwise.
  */
 static bool handle_subflow(struct l_genl_msg *msg,
-                           mptcpd_token_t const **token,
+                           mptcpd_token_t const *token,
                            struct mptcpd_addr *laddr,
                            struct mptcpd_addr *raddr,
                            bool *backup)
@@ -547,7 +547,7 @@ static bool handle_subflow(struct l_genl_msg *msg,
         while (l_genl_attr_next(&attr, &type, &len, &data)) {
                 switch (type) {
                 case MPTCP_ATTR_TOKEN:
-                        MPTCP_GET_NL_ATTR(data, len, *token);
+                        MPTCP_GET_NL_ATTR(data, len, token);
                         break;
                 case MPTCP_ATTR_SADDR4:
                         MPTCP_GET_NL_ATTR(data, len, laddr4);
@@ -615,7 +615,7 @@ static void handle_new_subflow(struct l_genl_msg *msg, void *user_data)
               Error (optional)
          */
 
-        mptcpd_token_t const *token  = NULL;
+        mptcpd_token_t token = 0;
         struct mptcpd_addr laddr;
         struct mptcpd_addr raddr;
         bool backup = false;
@@ -625,7 +625,7 @@ static void handle_new_subflow(struct l_genl_msg *msg, void *user_data)
 
         struct mptcpd_pm *const pm = user_data;
 
-        mptcpd_plugin_new_subflow(*token, &laddr, &raddr, backup, pm);
+        mptcpd_plugin_new_subflow(token, &laddr, &raddr, backup, pm);
 }
 
 static void handle_subflow_closed(struct l_genl_msg *msg, void *user_data)
@@ -643,7 +643,7 @@ static void handle_subflow_closed(struct l_genl_msg *msg, void *user_data)
               Error (optional)
          */
 
-        mptcpd_token_t const *token  = NULL;
+        mptcpd_token_t token = 0;
         struct mptcpd_addr laddr;
         struct mptcpd_addr raddr;
         bool backup = false;
@@ -653,7 +653,7 @@ static void handle_subflow_closed(struct l_genl_msg *msg, void *user_data)
 
         struct mptcpd_pm *const pm = user_data;
 
-        mptcpd_plugin_subflow_closed(*token, &laddr, &raddr, backup, pm);
+        mptcpd_plugin_subflow_closed(token, &laddr, &raddr, backup, pm);
 }
 
 static void handle_priority_changed(struct l_genl_msg *msg,
@@ -672,7 +672,7 @@ static void handle_priority_changed(struct l_genl_msg *msg,
               Error (optional)
          */
 
-        mptcpd_token_t const *token  = NULL;
+        mptcpd_token_t token = 0;
         struct mptcpd_addr laddr;
         struct mptcpd_addr raddr;
         bool backup = false;
@@ -682,7 +682,7 @@ static void handle_priority_changed(struct l_genl_msg *msg,
 
         struct mptcpd_pm *const pm = user_data;
 
-        mptcpd_plugin_subflow_priority(*token,
+        mptcpd_plugin_subflow_priority(token,
                                        &laddr,
                                        &raddr,
                                        backup,

--- a/src/path_manager.c
+++ b/src/path_manager.c
@@ -532,6 +532,7 @@ static bool handle_subflow(struct l_genl_msg *msg,
               Error (optional)
          */
 
+        *token                             = NULL;
         struct in_addr  const *laddr4      = NULL;
         struct in_addr  const *raddr4      = NULL;
         struct in6_addr const *laddr6      = NULL;
@@ -578,7 +579,7 @@ static bool handle_subflow(struct l_genl_msg *msg,
                 }
         }
 
-        if (!token
+        if (!*token
             || !(laddr4 || laddr6)
             || !local_port
             || !(raddr4 || raddr6)
@@ -590,7 +591,7 @@ static bool handle_subflow(struct l_genl_msg *msg,
                 return false;
         }
 
-        l_debug("token: 0x%" MPTCPD_PRIxTOKEN, *token);
+        l_debug("token: 0x%" MPTCPD_PRIxTOKEN, **token);
 
         get_mptcpd_addr(laddr4, laddr6, *local_port,  laddr);
         get_mptcpd_addr(raddr4, raddr6, *remote_port, raddr);

--- a/src/path_manager.c
+++ b/src/path_manager.c
@@ -503,7 +503,7 @@ static void handle_addr_removed(struct l_genl_msg *msg, void *user_data)
  * @return @c true on success, @c false otherwise.
  */
 static bool handle_subflow(struct l_genl_msg *msg,
-                           mptcpd_token_t const **token,
+                           mptcpd_token_t *token,
                            struct mptcpd_addr *laddr,
                            struct mptcpd_addr *raddr,
                            bool *backup)
@@ -532,7 +532,7 @@ static bool handle_subflow(struct l_genl_msg *msg,
               Error (optional)
          */
 
-        *token                             = NULL;
+        mptcpd_token_t  const *tok         = NULL;
         struct in_addr  const *laddr4      = NULL;
         struct in_addr  const *raddr4      = NULL;
         struct in6_addr const *laddr6      = NULL;
@@ -548,7 +548,7 @@ static bool handle_subflow(struct l_genl_msg *msg,
         while (l_genl_attr_next(&attr, &type, &len, &data)) {
                 switch (type) {
                 case MPTCP_ATTR_TOKEN:
-                        MPTCP_GET_NL_ATTR(data, len, *token);
+                        MPTCP_GET_NL_ATTR(data, len, tok);
                         break;
                 case MPTCP_ATTR_SADDR4:
                         MPTCP_GET_NL_ATTR(data, len, laddr4);
@@ -579,7 +579,7 @@ static bool handle_subflow(struct l_genl_msg *msg,
                 }
         }
 
-        if (!*token
+        if (!tok
             || !(laddr4 || laddr6)
             || !local_port
             || !(raddr4 || raddr6)
@@ -591,7 +591,9 @@ static bool handle_subflow(struct l_genl_msg *msg,
                 return false;
         }
 
-        l_debug("token: 0x%" MPTCPD_PRIxTOKEN, **token);
+        *token = *tok;
+
+        l_debug("token: 0x%" MPTCPD_PRIxTOKEN, *token);
 
         get_mptcpd_addr(laddr4, laddr6, *local_port,  laddr);
         get_mptcpd_addr(raddr4, raddr6, *remote_port, raddr);
@@ -616,7 +618,7 @@ static void handle_new_subflow(struct l_genl_msg *msg, void *user_data)
               Error (optional)
          */
 
-        mptcpd_token_t const *token  = NULL;
+        mptcpd_token_t token = 0;
         struct mptcpd_addr laddr;
         struct mptcpd_addr raddr;
         bool backup = false;
@@ -626,7 +628,7 @@ static void handle_new_subflow(struct l_genl_msg *msg, void *user_data)
 
         struct mptcpd_pm *const pm = user_data;
 
-        mptcpd_plugin_new_subflow(*token, &laddr, &raddr, backup, pm);
+        mptcpd_plugin_new_subflow(token, &laddr, &raddr, backup, pm);
 }
 
 static void handle_subflow_closed(struct l_genl_msg *msg, void *user_data)
@@ -644,7 +646,7 @@ static void handle_subflow_closed(struct l_genl_msg *msg, void *user_data)
               Error (optional)
          */
 
-        mptcpd_token_t const *token  = NULL;
+        mptcpd_token_t token = 0;
         struct mptcpd_addr laddr;
         struct mptcpd_addr raddr;
         bool backup = false;
@@ -654,7 +656,7 @@ static void handle_subflow_closed(struct l_genl_msg *msg, void *user_data)
 
         struct mptcpd_pm *const pm = user_data;
 
-        mptcpd_plugin_subflow_closed(*token, &laddr, &raddr, backup, pm);
+        mptcpd_plugin_subflow_closed(token, &laddr, &raddr, backup, pm);
 }
 
 static void handle_priority_changed(struct l_genl_msg *msg,
@@ -673,7 +675,7 @@ static void handle_priority_changed(struct l_genl_msg *msg,
               Error (optional)
          */
 
-        mptcpd_token_t const *token  = NULL;
+        mptcpd_token_t token = 0;
         struct mptcpd_addr laddr;
         struct mptcpd_addr raddr;
         bool backup = false;
@@ -683,11 +685,7 @@ static void handle_priority_changed(struct l_genl_msg *msg,
 
         struct mptcpd_pm *const pm = user_data;
 
-        mptcpd_plugin_subflow_priority(*token,
-                                       &laddr,
-                                       &raddr,
-                                       backup,
-                                       pm);
+        mptcpd_plugin_subflow_priority(token, &laddr, &raddr, backup, pm);
 }
 
 static void handle_mptcp_event(struct l_genl_msg *msg, void *user_data)

--- a/src/path_manager.c
+++ b/src/path_manager.c
@@ -538,7 +538,7 @@ static bool handle_subflow(struct l_genl_msg *msg,
         struct in6_addr const *raddr6      = NULL;
         in_port_t       const *local_port  = NULL;
         in_port_t       const *remote_port = NULL;
-        *backup                            = false;
+        uint8_t         const *bkup        = NULL;
 
         uint16_t type;
         uint16_t len;
@@ -568,14 +568,7 @@ static bool handle_subflow(struct l_genl_msg *msg,
                         MPTCP_GET_NL_ATTR(data, len, remote_port);
                         break;
                 case MPTCP_ATTR_BACKUP:
-                        /*
-                          The backup attribute is a NLA_FLAG,
-                          meaning its existence *is* the flag.  No
-                          payload data exists in such an attribute.
-                         */
-                        assert(validate_attr_len(len, 0));
-                        assert(data == NULL);
-                        *backup = true;
+                        MPTCP_GET_NL_ATTR(data, len, bkup);
                         break;
                 default:
                         l_warn("Unknown MPTCP_EVENT_SUB_* "
@@ -589,7 +582,8 @@ static bool handle_subflow(struct l_genl_msg *msg,
             || !(laddr4 || laddr6)
             || !local_port
             || !(raddr4 || raddr6)
-            || !remote_port) {
+            || !remote_port
+            || !backup) {
                 l_error("Required MPTCP_EVENT_SUB_* "
                         "message attributes are missing.");
 
@@ -600,6 +594,8 @@ static bool handle_subflow(struct l_genl_msg *msg,
 
         get_mptcpd_addr(laddr4, laddr6, *local_port,  laddr);
         get_mptcpd_addr(raddr4, raddr6, *remote_port, raddr);
+
+        *backup = *bkup;
 
         return true;
 }

--- a/src/path_manager.c
+++ b/src/path_manager.c
@@ -202,6 +202,13 @@ static void handle_connection_created(struct l_genl_msg *msg,
                 case MPTCP_ATTR_DPORT:
                         MPTCP_GET_NL_ATTR(data, len, remote_port);
                         break;
+                case MPTCP_ATTR_FAMILY:
+                case MPTCP_ATTR_LOC_ID:
+                case MPTCP_ATTR_REM_ID:
+                case MPTCP_ATTR_BACKUP:
+                case MPTCP_ATTR_IF_IDX:
+                        // Unused and ignored, at least for now.
+                        break;
 #ifdef MPTCPD_ENABLE_PM_NAME
                 case MPTCP_ATTR_PATH_MANAGER:
                         pm_name = get_pm_name(data, len);
@@ -289,6 +296,13 @@ static void handle_connection_established(struct l_genl_msg *msg,
                         break;
                 case MPTCP_ATTR_DPORT:
                         MPTCP_GET_NL_ATTR(data, len, remote_port);
+                        break;
+                case MPTCP_ATTR_FAMILY:
+                case MPTCP_ATTR_LOC_ID:
+                case MPTCP_ATTR_REM_ID:
+                case MPTCP_ATTR_BACKUP:
+                case MPTCP_ATTR_IF_IDX:
+                        // Unused and ignored, at least for now.
                         break;
                 default:
                         l_warn("Unknown MPTCP_EVENT_ESTABLISHED "

--- a/src/path_manager.c
+++ b/src/path_manager.c
@@ -503,7 +503,7 @@ static void handle_addr_removed(struct l_genl_msg *msg, void *user_data)
  * @return @c true on success, @c false otherwise.
  */
 static bool handle_subflow(struct l_genl_msg *msg,
-                           mptcpd_token_t const *token,
+                           mptcpd_token_t const **token,
                            struct mptcpd_addr *laddr,
                            struct mptcpd_addr *raddr,
                            bool *backup)
@@ -547,7 +547,7 @@ static bool handle_subflow(struct l_genl_msg *msg,
         while (l_genl_attr_next(&attr, &type, &len, &data)) {
                 switch (type) {
                 case MPTCP_ATTR_TOKEN:
-                        MPTCP_GET_NL_ATTR(data, len, token);
+                        MPTCP_GET_NL_ATTR(data, len, *token);
                         break;
                 case MPTCP_ATTR_SADDR4:
                         MPTCP_GET_NL_ATTR(data, len, laddr4);
@@ -615,7 +615,7 @@ static void handle_new_subflow(struct l_genl_msg *msg, void *user_data)
               Error (optional)
          */
 
-        mptcpd_token_t token = 0;
+        mptcpd_token_t const *token  = NULL;
         struct mptcpd_addr laddr;
         struct mptcpd_addr raddr;
         bool backup = false;
@@ -625,7 +625,7 @@ static void handle_new_subflow(struct l_genl_msg *msg, void *user_data)
 
         struct mptcpd_pm *const pm = user_data;
 
-        mptcpd_plugin_new_subflow(token, &laddr, &raddr, backup, pm);
+        mptcpd_plugin_new_subflow(*token, &laddr, &raddr, backup, pm);
 }
 
 static void handle_subflow_closed(struct l_genl_msg *msg, void *user_data)
@@ -643,7 +643,7 @@ static void handle_subflow_closed(struct l_genl_msg *msg, void *user_data)
               Error (optional)
          */
 
-        mptcpd_token_t token = 0;
+        mptcpd_token_t const *token  = NULL;
         struct mptcpd_addr laddr;
         struct mptcpd_addr raddr;
         bool backup = false;
@@ -653,7 +653,7 @@ static void handle_subflow_closed(struct l_genl_msg *msg, void *user_data)
 
         struct mptcpd_pm *const pm = user_data;
 
-        mptcpd_plugin_subflow_closed(token, &laddr, &raddr, backup, pm);
+        mptcpd_plugin_subflow_closed(*token, &laddr, &raddr, backup, pm);
 }
 
 static void handle_priority_changed(struct l_genl_msg *msg,
@@ -672,7 +672,7 @@ static void handle_priority_changed(struct l_genl_msg *msg,
               Error (optional)
          */
 
-        mptcpd_token_t token = 0;
+        mptcpd_token_t const *token  = NULL;
         struct mptcpd_addr laddr;
         struct mptcpd_addr raddr;
         bool backup = false;
@@ -682,7 +682,7 @@ static void handle_priority_changed(struct l_genl_msg *msg,
 
         struct mptcpd_pm *const pm = user_data;
 
-        mptcpd_plugin_subflow_priority(token,
+        mptcpd_plugin_subflow_priority(*token,
                                        &laddr,
                                        &raddr,
                                        backup,


### PR DESCRIPTION
Some MPTCP generic netlink message and command payloads were not correctly or fully migrated to the new API in PR #15.  Update those that were missed.