### PR TITLE
Improve code coverage.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -16,7 +16,7 @@ MOSTLYCLEANFILES = $(DX_CLEANFILES)
 EXTRA_DIST = README.md Doxyfile mptcpd.dox LICENSES
 
 README: $(top_srcdir)/README.md
-	@test -z "$(PANDOC)" || $(PANDOC) --from markdown_github --to plain --output=$@ --normalize $<
+	@test -z "$(PANDOC)" || $(PANDOC) --from markdown_github --to plain --output=$@ $<
 
 dist-hook: README
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ archive or from a cloned Git `mptcpd` repository, for example.
   * [GNU Automake](https://www.gnu.org/software/automake/)
   * [GNU Libtool](https://www.gnu.org/software/libtool/)
   * [GNU Autoconf Archive](https://www.gnu.org/software/autoconf-archive/)
-  * [Pandoc](https://pandoc.org/) (needed to convert `README.md`
+  * [Pandoc](https://pandoc.org/) >= 2.2.1 (needed to convert `README.md`
     contents from the GitHub markdown format content to plain text)
   * [Doxygen](http://www.doxygen.nl/) (only needed to build
     documentation)

--- a/configure.ac
+++ b/configure.ac
@@ -137,7 +137,8 @@ AS_IF([test "x$ax_enable_debug" != "xyes"],
        dnl Explicitly add compile-time optimization flag since
        dnl AX_ENABLE_DEBUG macro disables the autoconf default of
        dnl implicitly adding it.
-       MPTCPD_ADD_COMPILE_FLAG([-O2])
+       AS_IF([test "x$enable_code_coverage" != "xyes"],
+             [MPTCPD_ADD_COMPILE_FLAG([-O2])])
 
        dnl AX_CODE_COVERAGE will define NDEBUG on the command line,
        dnl equivalent to #define NDEBUG 1, if code coverage is

--- a/include/mptcpd/plugin.h
+++ b/include/mptcpd/plugin.h
@@ -10,6 +10,8 @@
 #ifndef MPTCPD_PLUGIN_H
 #define MPTCPD_PLUGIN_H
 
+#include <stdbool.h>
+
 #include <mptcpd/export.h>
 #include <mptcpd/types.h>
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -7,6 +7,17 @@ AM_CPPFLAGS = -I$(top_srcdir)/include
 AM_CFLAGS   = $(ELL_CFLAGS) $(EXECUTABLE_CFLAGS)
 AM_LDFLAGS  = $(EXECUTABLE_LDFLAGS)
 
+## Convenience library that contains utility functions used by the
+## mptcpd tests.
+noinst_LTLIBRARIES = libmptcpd_test.la
+
+libmptcpd_test_la_SOURCES = call_count.c call_plugin.c mptcpd_addr.c
+libmptcpd_test_la_CPPFLAGS =					\
+	-I$(top_srcdir)/include -I$(top_builddir)/include	\
+	$(CODE_COVERAGE_CPPFLAGS) $(AM_CPPFLAGS)
+libmptcpd_test_la_CFLAGS = $(ELL_CFLAGS) $(CODE_COVERAGE_CFLAGS)
+libmptcpd_test_la_LIBADD = $(ELL_LIBS) $(CODE_COVERAGE_LIBS)
+
 ## Build a test mptcpd plugin.
 ##
 ## "check_LTLIBRARIES" can't be used here since a dynamically loadable
@@ -60,7 +71,7 @@ plugin_one_la_CPPFLAGS = \
 	-I$(top_srcdir)/include
 plugin_one_la_CFLAGS   = $(ELL_CFLAGS)
 plugin_one_la_LDFLAGS  = -no-undefined -module -avoid-version $(ELL_LIBS)
-plugin_one_la_LIBADD   = $(PLUGIN_LIBMPTCPD_FLAGS)
+plugin_one_la_LIBADD   = $(PLUGIN_LIBMPTCPD_FLAGS) libmptcpd_test.la
 
 plugin_two_la_SOURCES  = plugin_two.c
 plugin_two_la_CPPFLAGS = \
@@ -68,7 +79,7 @@ plugin_two_la_CPPFLAGS = \
 	-I$(top_srcdir)/include
 plugin_two_la_CFLAGS   = $(ELL_CFLAGS)
 plugin_two_la_LDFLAGS  = -no-undefined -module -avoid-version $(ELL_LIBS)
-plugin_two_la_LIBADD   = $(PLUGIN_LIBMPTCPD_FLAGS)
+plugin_two_la_LIBADD   = $(PLUGIN_LIBMPTCPD_FLAGS) libmptcpd_test.la
 
 plugin_three_la_SOURCES  = plugin_three.c
 plugin_three_la_CPPFLAGS = \
@@ -76,7 +87,7 @@ plugin_three_la_CPPFLAGS = \
 	-I$(top_srcdir)/include
 plugin_three_la_CFLAGS   = $(ELL_CFLAGS)
 plugin_three_la_LDFLAGS  = -no-undefined -module -avoid-version $(ELL_LIBS)
-plugin_three_la_LIBADD   = $(PLUGIN_LIBMPTCPD_FLAGS)
+plugin_three_la_LIBADD   = $(PLUGIN_LIBMPTCPD_FLAGS) libmptcpd_test.la
 
 plugin_four_la_SOURCES  = plugin_four.c
 plugin_four_la_CPPFLAGS = \
@@ -85,7 +96,7 @@ plugin_four_la_CPPFLAGS = \
 plugin_four_la_CFLAGS   = $(ELL_CFLAGS)
 plugin_four_la_LDFLAGS  = \
 	-no-undefined -module -avoid-version $(ELL_LIBS)
-plugin_four_la_LIBADD   = $(PLUGIN_LIBMPTCPD_FLAGS)
+plugin_four_la_LIBADD   = $(PLUGIN_LIBMPTCPD_FLAGS) libmptcpd_test.la
 
 plugin_noop_la_SOURCES  = plugin_noop.c
 plugin_noop_la_CPPFLAGS = \
@@ -135,7 +146,10 @@ test_plugin_CPPFLAGS =					\
 	-DTEST_PLUGIN_ONE=\"$(TEST_PLUGIN_ONE)\"	\
 	-DTEST_PLUGIN_TWO=\"$(TEST_PLUGIN_TWO)\"	\
 	-DTEST_PLUGIN_FOUR=\"$(TEST_PLUGIN_FOUR)\"
-test_plugin_LDADD = $(top_builddir)/lib/libmptcpd.la $(ELL_LIBS)
+test_plugin_LDADD =				\
+	$(top_builddir)/lib/libmptcpd.la	\
+	libmptcpd_test.la			\
+	$(ELL_LIBS)
 
 test_network_monitor_SOURCES = test-network-monitor.c
 test_network_monitor_LDADD = $(top_builddir)/lib/libmptcpd.la $(ELL_LIBS)
@@ -159,7 +173,7 @@ test_commands_LDADD =				\
 	$(ELL_LIBS)
 
 test_configuration_SOURCES = test-configuration.c
-test_configuration_LDADD =				\
+test_configuration_LDADD =			\
 	$(top_builddir)/src/libpath_manager.la	\
 	$(top_builddir)/lib/libmptcpd.la	\
 	$(ELL_LIBS)
@@ -172,7 +186,10 @@ test_cxx_build_CPPFLAGS =				\
 	-DTEST_PLUGIN_DIR=\"$(TEST_PLUGIN_DIR_A)\"	\
 	-DTEST_PLUGIN_FOUR=\"$(TEST_PLUGIN_FOUR)\"
 test_cxx_build_CXXFLAGS = $(AM_CFLAGS)
-test_cxx_build_LDADD = $(top_builddir)/lib/libmptcpd.la $(ELL_LIBS)
+test_cxx_build_LDADD =				\
+	$(top_builddir)/lib/libmptcpd.la	\
+	libmptcpd_test.la			\
+	$(ELL_LIBS)
 endif
 
 ## "Install" test plugins, as needed, prior to running the tests.

--- a/tests/call_count.c
+++ b/tests/call_count.c
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/**
+ * @file call-count.c
+ *
+ * @brief mptcpd test plugin call count functions.
+ *
+ * Copyright (c) 2019, Intel Corporation
+ */
+
+#include <stdlib.h>
+
+#include "test-plugin.h"
+
+
+void call_count_reset(struct plugin_call_count *p)
+{
+        p->new_connection         = 0;
+        p->connection_established = 0;
+        p->connection_closed      = 0;
+        p->new_address            = 0;
+        p->address_removed        = 0;
+        p->new_subflow            = 0;
+        p->subflow_closed         = 0;
+        p->subflow_priority       = 0;
+}
+
+bool call_count_all_positive(struct plugin_call_count const *p)
+{
+        return     p->new_connection >= 0
+                && p->connection_established >= 0
+                && p->connection_closed >= 0
+                && p->new_address >= 0
+                && p->address_removed >= 0
+                && p->new_subflow >= 0
+                && p->subflow_closed >= 0
+                && p->subflow_priority >= 0;
+}
+
+bool call_count_is_sane(struct plugin_call_count const *p)
+{
+        return  // non-negative counts
+                call_count_all_positive(p)
+
+                /*
+                  Some callbacks should not be called more than
+                  others.
+                */
+                && p->connection_established <= p->new_connection
+                && p->connection_closed <= p->new_connection
+                && p->subflow_closed    <= p->new_subflow;
+}
+
+bool call_count_is_equal(struct plugin_call_count const *lhs,
+                         struct plugin_call_count const *rhs)
+{
+        return lhs->new_connection         == rhs->new_connection
+            && lhs->connection_established == rhs->connection_established
+            && lhs->connection_closed      == rhs->connection_closed
+            && lhs->new_address            == rhs->new_address
+            && lhs->address_removed        == rhs->address_removed
+            && lhs->new_subflow            == rhs->new_subflow
+            && lhs->subflow_closed         == rhs->subflow_closed
+            && lhs->subflow_priority       == rhs->subflow_priority;
+
+}

--- a/tests/call_plugin.c
+++ b/tests/call_plugin.c
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/**
+ * @file call_plugin.c
+ *
+ * @brief mptcpd test plugin call functions.
+ *
+ * Copyright (c) 2019, Intel Corporation
+ */
+
+#include <assert.h>
+#include <stdlib.h>
+
+#include <mptcpd/plugin.h>
+
+#include "test-plugin.h"
+
+
+void call_plugin_ops(struct plugin_call_count const *count,
+                     char const *name,
+                     mptcpd_token_t token,
+                     mptcpd_aid_t raddr_id,
+                     struct mptcpd_addr const *laddr,
+                     struct mptcpd_addr const *raddr,
+                     bool backup)
+{
+        assert(count != NULL);
+
+        for (int i = 0; i < count->new_connection; ++i)
+                mptcpd_plugin_new_connection(name,
+                                             token,
+                                             laddr,
+                                             raddr,
+                                             NULL);
+
+        for (int i = 0; i < count->connection_established; ++i)
+                mptcpd_plugin_connection_established(token,
+                                                     laddr,
+                                                     raddr,
+                                                     NULL);
+
+        for (int i = 0; i < count->new_address; ++i)
+                mptcpd_plugin_new_address(token,
+                                          raddr_id,
+                                          raddr,
+                                          NULL);
+
+        for (int i = 0; i < count->address_removed; ++i)
+                mptcpd_plugin_address_removed(token,
+                                              raddr_id,
+                                              NULL);
+
+        for (int i = 0; i < count->new_subflow; ++i)
+                mptcpd_plugin_new_subflow(token,
+                                          laddr,
+                                          raddr,
+                                          backup,
+                                          NULL);
+
+        for (int i = 0; i < count->subflow_closed; ++i)
+                mptcpd_plugin_subflow_closed(token,
+                                             laddr,
+                                             raddr,
+                                             backup,
+                                             NULL);
+
+        for (int i = 0; i < count->subflow_priority; ++i)
+                mptcpd_plugin_subflow_priority(token,
+                                               laddr,
+                                               raddr,
+                                               backup,
+                                               NULL);
+
+        for (int i = 0; i < count->connection_closed; ++i)
+                mptcpd_plugin_connection_closed(token, NULL);
+}

--- a/tests/mptcpd_addr.c
+++ b/tests/mptcpd_addr.c
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/**
+ * @file mptcpd_addr.c
+ *
+ * @brief mptcpd_addr related test functions.
+ *
+ * Copyright (c) 2019, Intel Corporation
+ */
+
+#include <string.h>
+
+#include "test-plugin.h"
+
+
+bool mptcpd_addr_is_equal(struct mptcpd_addr const *lhs,
+                          struct mptcpd_addr const *rhs)
+{
+        if (lhs->address.family == rhs->address.family
+            && lhs->port == rhs->port) {
+                struct mptcpd_in_addr const *const left =
+                        &lhs->address;
+                struct mptcpd_in_addr const *const right =
+                        &rhs->address;
+
+                if (lhs->address.family == AF_INET)
+                        return left->addr.addr4.s_addr
+                                == right->addr.addr4.s_addr;
+                else
+                        // memcmp() is fine for this case.
+                        return memcmp(
+                                &left->addr.addr6.s6_addr,
+                                &right->addr.addr6.s6_addr,
+                                sizeof(left->addr.addr6.s6_addr)) == 0;
+        }
+
+        return false;
+}

--- a/tests/plugin_four.c
+++ b/tests/plugin_four.c
@@ -161,10 +161,10 @@ static int plugin_four_init(void)
 
 static void plugin_four_exit(void)
 {
-        assert(plugin_call_count_is_sane(&call_count));
-        assert(plugin_call_count_is_equal(&call_count, &test_count_4));
+        assert(call_count_is_sane(&call_count));
+        assert(call_count_is_equal(&call_count, &test_count_4));
 
-        plugin_call_count_reset(&call_count);
+        call_count_reset(&call_count);
 }
 
 L_PLUGIN_DEFINE(MPTCPD_PLUGIN_DESC,

--- a/tests/plugin_one.c
+++ b/tests/plugin_one.c
@@ -191,10 +191,10 @@ static void plugin_one_exit(void)
                 .subflow_priority  = test_count_1.subflow_priority  * 2,
         };
 
-        assert(plugin_call_count_is_sane(&call_count));
-        assert(plugin_call_count_is_equal(&call_count, &count));
+        assert(call_count_is_sane(&call_count));
+        assert(call_count_is_equal(&call_count, &count));
 
-        plugin_call_count_reset(&call_count);
+        call_count_reset(&call_count);
 }
 
 L_PLUGIN_DEFINE(MPTCPD_PLUGIN_DESC,

--- a/tests/plugin_three.c
+++ b/tests/plugin_three.c
@@ -163,10 +163,10 @@ static void plugin_three_exit(void)
 {
         struct plugin_call_count const count = { .new_connection = 0 };
 
-        assert(plugin_call_count_is_sane(&call_count));
-        assert(plugin_call_count_is_equal(&call_count, &count));
+        assert(call_count_is_sane(&call_count));
+        assert(call_count_is_equal(&call_count, &count));
 
-        plugin_call_count_reset(&call_count);
+        call_count_reset(&call_count);
 }
 
 L_PLUGIN_DEFINE(MPTCPD_PLUGIN_DESC,

--- a/tests/plugin_two.c
+++ b/tests/plugin_two.c
@@ -175,10 +175,10 @@ static int plugin_two_init(void)
 
 static void plugin_two_exit(void)
 {
-        assert(plugin_call_count_is_sane(&call_count));
-        assert(plugin_call_count_is_equal(&call_count, &test_count_2));
+        assert(call_count_is_sane(&call_count));
+        assert(call_count_is_equal(&call_count, &test_count_2));
 
-        plugin_call_count_reset(&call_count);
+        call_count_reset(&call_count);
 }
 
 L_PLUGIN_DEFINE(MPTCPD_PLUGIN_DESC,

--- a/tests/test-commands.c
+++ b/tests/test-commands.c
@@ -70,6 +70,13 @@ void test_remove_subflow(void const *test_data)
                                         &test_raddr_1));
 }
 
+void test_get_nm(void const *test_data)
+{
+        struct mptcpd_pm *const pm = (struct mptcpd_pm *) test_data;
+
+        assert(mptcpd_pm_get_nm(pm) != NULL);
+}
+
 // -------------------------------------------------------------------
 
 static void idle_callback(struct l_idle *idle, void *user_data)
@@ -150,6 +157,7 @@ int main(void)
         l_test_add("add_subflow",    test_add_subflow,    pm);
         l_test_add("set_backup",     test_set_backup,     pm);
         l_test_add("remove_subflow", test_remove_subflow, pm);
+        l_test_add("get_nm",         test_get_nm,         pm);
 
         /*
           Prepare to run the path management generic netlink command

--- a/tests/test-plugin.h
+++ b/tests/test-plugin.h
@@ -10,15 +10,14 @@
 #ifndef MPTCPD_TEST_PLUGIN_H
 #define MPTCPD_TEST_PLUGIN_H
 
-#include <string.h>
+#include <stdbool.h>
 
 #include <mptcpd/types.h>
-#include <mptcpd/plugin.h>
+
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
 
 // ------------------------------------------------------------------
 
@@ -51,58 +50,26 @@ struct plugin_call_count
         //@}
 };
 
-inline void plugin_call_count_reset(struct plugin_call_count *p)
-{
-        p->new_connection         = 0;
-        p->connection_established = 0;
-        p->connection_closed      = 0;
-        p->new_address            = 0;
-        p->address_removed        = 0;
-        p->new_subflow            = 0;
-        p->subflow_closed         = 0;
-        p->subflow_priority       = 0;
-}
+/**
+ * @brief Reset plugin operation call counts.
+ */
+void call_count_reset(struct plugin_call_count *p);
 
-inline bool plugin_call_counts_are_pos(struct plugin_call_count const *p)
-{
-        return     p->new_connection >= 0
-                && p->connection_established >= 0
-                && p->connection_closed >= 0
-                && p->new_address >= 0
-                && p->address_removed >= 0
-                && p->new_subflow >= 0
-                && p->subflow_closed >= 0
-                && p->subflow_priority >= 0;
-}
+/**
+ * @brief Check if all plugin operation call counts are not negative.
+ */
+bool call_count_all_positive(struct plugin_call_count const *p);
 
-inline bool plugin_call_count_is_sane(struct plugin_call_count const *p)
-{
-        return  // non-negative counts
-                plugin_call_counts_are_pos(p)
+/**
+ * @brief Perform a sanity check on the plugin operation call counts.
+ */
+bool call_count_is_sane(struct plugin_call_count const *p);
 
-                /*
-                  Some callbacks should not be called more than
-                  others.
-                */
-                && p->connection_established <= p->new_connection
-                && p->connection_closed <= p->new_connection
-                && p->subflow_closed    <= p->new_subflow;
-}
-
-inline bool plugin_call_count_is_equal(
-        struct plugin_call_count const *lhs,
-        struct plugin_call_count const *rhs)
-{
-        return lhs->new_connection         == rhs->new_connection
-            && lhs->connection_established == rhs->connection_established
-            && lhs->connection_closed      == rhs->connection_closed
-            && lhs->new_address            == rhs->new_address
-            && lhs->address_removed        == rhs->address_removed
-            && lhs->new_subflow            == rhs->new_subflow
-            && lhs->subflow_closed         == rhs->subflow_closed
-            && lhs->subflow_priority       == rhs->subflow_priority;
-
-}
+/**
+ * @brief Compare plugin operation call counts for equality.
+ */
+bool call_count_is_equal(struct plugin_call_count const *lhs,
+                         struct plugin_call_count const *rhs);
 
 // ------------------------------------------------------------------
 
@@ -114,7 +81,7 @@ inline bool plugin_call_count_is_equal(
  * intended to call were actually called.
  */
 //@{
-struct plugin_call_count const test_count_1 = {
+static struct plugin_call_count const test_count_1 = {
         .new_connection         = 1,
         .connection_established = 1,
         .connection_closed      = 1,
@@ -125,7 +92,7 @@ struct plugin_call_count const test_count_1 = {
         .subflow_priority       = 0
 };
 
-struct plugin_call_count const test_count_2 = {
+static struct plugin_call_count const test_count_2 = {
         .new_connection         = 1,
         .connection_established = 1,
         .connection_closed      = 1,
@@ -136,7 +103,7 @@ struct plugin_call_count const test_count_2 = {
         .subflow_priority       = 1
 };
 
-struct plugin_call_count const test_count_4 = {
+static struct plugin_call_count const test_count_4 = {
         .new_connection         = 1,
         .connection_established = 1,
         .connection_closed      = 1,
@@ -148,7 +115,6 @@ struct plugin_call_count const test_count_4 = {
 };
 //@}
 
-
 // ------------------------------------------------------------------
 
 /**
@@ -159,31 +125,31 @@ struct plugin_call_count const test_count_4 = {
  * types of values they correspond to.
  */
 //@{
-mptcpd_token_t const test_token_1    = 0x12345678;
-mptcpd_aid_t   const test_laddr_id_1 = 0x34;
-mptcpd_aid_t   const test_raddr_id_1 = 0x56;
-bool           const test_backup_1   = true;
+static mptcpd_token_t const test_token_1    = 0x12345678;
+static mptcpd_aid_t   const test_laddr_id_1 = 0x34;
+static mptcpd_aid_t   const test_raddr_id_1 = 0x56;
+static bool           const test_backup_1   = true;
 
-mptcpd_token_t const test_token_2    = 0x23456789;
-mptcpd_aid_t   const test_laddr_id_2 = 0x23;
-mptcpd_aid_t   const test_raddr_id_2 = 0x45;
-bool           const test_backup_2   = false;
+static mptcpd_token_t const test_token_2    = 0x23456789;
+static mptcpd_aid_t   const test_laddr_id_2 = 0x23;
+static mptcpd_aid_t   const test_raddr_id_2 = 0x45;
+static bool           const test_backup_2   = false;
 
-mptcpd_token_t const test_token_4    = 0x34567890;
-mptcpd_aid_t   const test_laddr_id_4 = 0x90;
-mptcpd_aid_t   const test_raddr_id_4 = 0x01;
-bool           const test_backup_4   = true;
+static mptcpd_token_t const test_token_4    = 0x34567890;
+static mptcpd_aid_t   const test_laddr_id_4 = 0x90;
+static mptcpd_aid_t   const test_raddr_id_4 = 0x01;
+static bool           const test_backup_4   = true;
 
 // For verifying that a plugin will not be dispatched.
-mptcpd_token_t const test_bad_token  = 0xFFFFFFFF;
+static mptcpd_token_t const test_bad_token  = 0xFFFFFFFF;
 
-struct mptcpd_addr const test_laddr_1 = {
+static struct mptcpd_addr const test_laddr_1 = {
         .address = { .family = AF_INET,
                      .addr   = { .addr4 = { .s_addr = 0x34567890 } } },
         .port    = 0x1234
 };
 
-struct mptcpd_addr const test_laddr_2 = {
+static struct mptcpd_addr const test_laddr_2 = {
 #ifdef __cplusplus
         /*
           s6_addr is a macro that expands to code that isn't
@@ -220,7 +186,7 @@ struct mptcpd_addr const test_laddr_2 = {
         .port    = 0x5678
 };
 
-struct mptcpd_addr const test_raddr_1 = {
+static struct mptcpd_addr const test_raddr_1 = {
 #ifdef __cplusplus
         /*
           s6_addr is a macro that expands to code that isn't
@@ -257,19 +223,19 @@ struct mptcpd_addr const test_raddr_1 = {
         .port    = 0x3456
 };
 
-struct mptcpd_addr const test_raddr_2 = {
+static struct mptcpd_addr const test_raddr_2 = {
         .address = { .family = AF_INET,
                      .addr   = { .addr4 = { .s_addr = 0x98765432 } } },
         .port    = 0x7890
 };
 
-struct mptcpd_addr const test_laddr_4 = {
+static struct mptcpd_addr const test_laddr_4 = {
         .address = { .family = AF_INET,
                      .addr   = { .addr4 = { .s_addr = 0x45678901 } } },
         .port    = 0x2345
 };
 
-struct mptcpd_addr const test_raddr_4 = {
+static struct mptcpd_addr const test_raddr_4 = {
         .address = { .family = AF_INET,
                      .addr   = { .addr4 = { .s_addr = 0x56789012 } } },
         .port    = 0x3456
@@ -279,89 +245,30 @@ struct mptcpd_addr const test_raddr_4 = {
 
 /**
  * @brief Compare equality of two @c mptcpd_addr objects.
+ *
+ * @return @c true if both @c mptcpd_addr objects are equal. @c false
+ *         otherwise.
  */
-extern bool mptcpd_addr_is_equal(struct mptcpd_addr const *lhs,
-                                 struct mptcpd_addr const *rhs)
-{
-        if (lhs->address.family == rhs->address.family
-            && lhs->port == rhs->port) {
-                struct mptcpd_in_addr const *const left =
-                        &lhs->address;
-                struct mptcpd_in_addr const *const right =
-                        &rhs->address;
+bool mptcpd_addr_is_equal(struct mptcpd_addr const *lhs,
+                          struct mptcpd_addr const *rhs);
 
-                if (lhs->address.family == AF_INET)
-                        return left->addr.addr4.s_addr
-                                == right->addr.addr4.s_addr;
-                else
-                        // memcmp() is fine for this case.
-                        return memcmp(
-                                &left->addr.addr6.s6_addr,
-                                &right->addr.addr6.s6_addr,
-                                sizeof(left->addr.addr6.s6_addr)) == 0;
-        }
-
-        return false;
-}
-
-extern void call_plugin_ops(struct plugin_call_count const *count,
-                            char const *name,
-                            mptcpd_token_t token,
-                            mptcpd_aid_t raddr_id,
-                            struct mptcpd_addr const *laddr,
-                            struct mptcpd_addr const *raddr,
-                            bool backup)
-{
-        assert(count != NULL);
-
-        for (int i = 0; i < count->new_connection; ++i)
-                mptcpd_plugin_new_connection(name,
-                                             token,
-                                             laddr,
-                                             raddr,
-                                             NULL);
-
-        for (int i = 0; i < count->connection_established; ++i)
-                mptcpd_plugin_connection_established(token,
-                                                     laddr,
-                                                     raddr,
-                                                     NULL);
-
-        for (int i = 0; i < count->new_address; ++i)
-                mptcpd_plugin_new_address(token,
-                                          raddr_id,
-                                          raddr,
-                                          NULL);
-
-        for (int i = 0; i < count->address_removed; ++i)
-                mptcpd_plugin_address_removed(token,
-                                              raddr_id,
-                                              NULL);
-
-        for (int i = 0; i < count->new_subflow; ++i)
-                mptcpd_plugin_new_subflow(token,
-                                          laddr,
-                                          raddr,
-                                          backup,
-                                          NULL);
-
-        for (int i = 0; i < count->subflow_closed; ++i)
-                mptcpd_plugin_subflow_closed(token,
-                                             laddr,
-                                             raddr,
-                                             backup,
-                                             NULL);
-
-        for (int i = 0; i < count->subflow_priority; ++i)
-                mptcpd_plugin_subflow_priority(token,
-                                               laddr,
-                                               raddr,
-                                               backup,
-                                               NULL);
-
-        for (int i = 0; i < count->connection_closed; ++i)
-                mptcpd_plugin_connection_closed(token, NULL);
-}
+/**
+ * @brief Call plugin operations
+ *
+ * @param[in] count    Number of times to call each plugin operation.
+ * @param[in] name     Plugin name.
+ * @param[in] raddr_id Remote address ID.
+ * @param[in] laddr    Local address.
+ * @param[in] raddr    Remote address.
+ * @param[in] backup   MPTCP backup priority.
+ */
+void call_plugin_ops(struct plugin_call_count const *count,
+                     char const *name,
+                     mptcpd_token_t token,
+                     mptcpd_aid_t raddr_id,
+                     struct mptcpd_addr const *laddr,
+                     struct mptcpd_addr const *raddr,
+                     bool backup);
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
Some areas of code in **mptcpd** were not reflected in code coverage results.  Improve the code coverage results by adding **mptcpd** library function calls to the unit test suite, as well as removing the "`-O2`" compiler optimization flag that interfered with the code coverage.
