### PR TITLE
lib: Fix abort on monitored net address removal.

### DIFF
--- a/lib/network_monitor.c
+++ b/lib/network_monitor.c
@@ -104,8 +104,7 @@ mptcpd_in_addr_create(struct mptcpd_rtm_addr const *info)
                   Kernel nla_put_in_addr() inserts a big endian 32
                   bit unsigned integer, not struct in_addr.
                 */
-                in_addr_t const sa =
-                        *(uint32_t const*) info->addr;
+                uint32_t const sa = *(uint32_t const*) info->addr;
 
                 address->addr.addr4.s_addr = sa;
         } else {
@@ -191,7 +190,7 @@ static bool mptcpd_in_addr_match(void const *a, void const *b)
                           endian 32 bit unsigned integer, not struct
                           in_addr.
                         */
-                        in_addr_t const sa = *(uint32_t const*) rhs->addr;
+                        uint32_t const sa = *(uint32_t const*) rhs->addr;
 
                         matched = (lhs->addr.addr4.s_addr == sa);
                 } else {


### PR DESCRIPTION
The network monitor code that removes a network address from
monitoring had a function parameter mismatch that was hidden a pointer
to void.  Correct the mismatch, and make all network monitor functions
that support the RTM_NEWADDR, RTM_DELADDR, and RTM_GETADDR rtnetlink
messages consistently use the same (internal) network address
information encapsulation type.  Fixes #27.