### PR TITLE
src: Explicitly grant CAP_NET_ADMIN capability.

### DIFF
--- a/src/mptcp.service.in
+++ b/src/mptcp.service.in
@@ -6,13 +6,13 @@
 Description=Multipath TCP service
 Documentation=man:mptcpd(8)
 
-
 [Service]
 Type=simple
 DynamicUser=yes
 Environment=LD_LIBRARY_PATH=@libdir@
 ExecStart=@libexecdir@/mptcpd --log=journal
 CapabilityBoundingSet=CAP_NET_ADMIN
+AmbientCapabilities=CAP_NET_ADMIN
 LimitNPROC=1
 
 [Install]


### PR DESCRIPTION
The multipath-tcp.org kernel's "netlink" path manager requires
processes that invoke commands over its generic netlink API to have
the CAP_NET_ADMIN capability.  However, the mptcpd mptcp.service file
doesn't explicitly grant that capability since it runs mptcpd under an
unprivileged dynamically created user (DynamicUser=yes), resulting in
mptcpd being in incapable of successfully issuing path management
commands to the kernel.

Add "AmbientCapabilities=CAP_NET_ADMIN" to grant mptcpd the necessary
capability when starting it through systemd.  Fixes #28.