### PR TITLE
network_monitor: Do not track removed address.

### DIFF
--- a/lib/network_monitor.c
+++ b/lib/network_monitor.c
@@ -578,10 +578,11 @@ static void insert_addr(struct ifaddrmsg const *ifa,
                         struct mptcpd_in_addr *const addr =
                                 mptcpd_in_addr_create(&info);
 
-                        if (!l_queue_insert(i->addrs,
-                                            addr,
-                                            mptcpd_in_addr_compare,
-                                            NULL)) {
+                        if (unlikely(addr == NULL)
+                            || !l_queue_insert(i->addrs,
+                                               addr,
+                                               mptcpd_in_addr_compare,
+                                               NULL)) {
                                 mptcpd_in_addr_destroy(addr);
 
                                 l_error("Unable to queue internet "
@@ -748,10 +749,12 @@ static void handle_ifaddr(uint16_t type,
                         struct mptcpd_in_addr *const addr =
                                 mptcpd_in_addr_create(&info);
 
-                        l_queue_insert(interface->addrs,
-                                       addr,
-                                       mptcpd_in_addr_compare,
-                                       NULL);
+                        if (unlikely(addr == NULL)
+                            || !l_queue_insert(interface->addrs,
+                                               addr,
+                                               mptcpd_in_addr_compare,
+                                               NULL))
+                                l_error("Unable to track new address");
                 }
         }
 

--- a/lib/network_monitor.c
+++ b/lib/network_monitor.c
@@ -664,10 +664,27 @@ static struct mptcpd_interface *get_mptcpd_interface(
         return interface;
 }
 
+/**
+ * @brief Network address handler function signature.
+ */
 typedef
 void (*handle_ifaddr_func_t)(struct l_queue *addrs,
                              struct mptcpd_rtm_addr const *rtm_addr);
 
+/**
+ * @brief @c RTM_NEWADDR and @c RTM_DELADDR attribute iteration.
+ *
+ * Call @a handler for all attributes found in a @c RTM_NEWADDR or
+ * @c RTM_DELADDR event.
+ *
+ * @param[in] ifa     Network address-specific information retrieved
+ *                    from @c RTM_NEWADDR or @c RTM_DELADDR messages.
+ * @param[in] len     Length of the rtnetlink message.
+ * @param[in] addrs   List of tracked network addresses.
+ * @param[in] handler Function to be called for each @c IFA_ADDRESS
+ *                    attribute in the @c RTM_NEWADDR or
+ *                    @c RTM_DELADDR event.
+ */
 static void foreach_ifaddr(struct ifaddrmsg const *ifa,
                            uint32_t len,
                            struct l_queue *addrs,


### PR DESCRIPTION
Tracked addresses to be removed due to a `RTM_DELADDR` rtnetlink event were needlessly re-inserted into the address queue prior to removal.   Refactor rtnetlink `RTM_NEWADDR` and `RTM_DELADDR` event `IFA_ADDRESS` attribute iteration to simplify handling of new, updated, and removed addresses.