### PR TITLE
mptcpd 0.2a: Alpha release

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -16,7 +16,7 @@ MOSTLYCLEANFILES = $(DX_CLEANFILES)
 EXTRA_DIST = README.md Doxyfile mptcpd.dox LICENSES
 
 README: $(top_srcdir)/README.md
-	@test -z "$(PANDOC)" || $(PANDOC) --from markdown_github --to plain --output=$@ $<
+	@test -z "$(PANDOC)" || $(PANDOC) --from gfm --to plain --output=$@ $<
 
 dist-hook: README
 

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,17 @@
+11 June 2019 - mptcpd 0.2a
+
+- This Multipath TCP Daemon alpha release replaces support for the
+  deprecated MPTCP generic netlink API with the one found in the
+  multipath-tcp.org kernel (0.95+), and has been verified to work with
+  that kernel.
+
+- Several actual and potential memory access violations were fixed in
+  the mptcpd network monitor, path manager, and "sspi" plugin.
+
+- The mptcp.service systemd service file now correctly grants the
+  necessary privilege (CAP_NET_ADMIN) for proper operation of the
+  mptcpd program.
+
 27 March 2019 - mptcpd 0.1a
 
 - This is the initial (alpha) release of the Multipath TCP Daemon

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ versions) without installation.
 
 ### Executing an Installed `mptcpd`
 #### Without `systemd`
-For now, `mptcpd` does not provide a traditional System V "init
+`mptcpd` currently does not provide traditional System V "init
 scripts".  In general the `mptcpd` program may be run directly from
 the installed directory, e.g.:
 
@@ -243,7 +243,7 @@ systemctl daemon-reload
 systemctl start mptcp.service
 ```
 
-These steps are not be necessary if the system is rebooted after
+These steps are not necessary if the system is rebooted after
 installation of `mptcpd`.
 
 ### Execution of `mptcpd` in the Source Distribution

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@
 
 AC_PREREQ([2.69])
 AC_INIT([mptcpd],
-        [0.1a],
+        [0.2a],
         [mptcp@lists.01.org],
         [],
         [https://01.org/multipath-tcp-linux])


### PR DESCRIPTION
* This Multipath TCP Daemon alpha release replaces support for the deprecated MPTCP generic netlink API with the one found in the multipath-tcp.org 0.95+ kernel (see multipath-tcp/mptcp@4ea5dee), and has been verified to work with that kernel.
* Several actual and potential memory access violations were fixed in the `mptcpd` network monitor, path manager, and "`sspi`" plugin.
* The `mptcp.service` systemd service file now correctly grants the necessary privilege (`CAP_NET_ADMIN`) for proper operation of the `mptcpd` program.