### PR TITLE
Transition to new ELL genl API.

### DIFF
--- a/include/mptcpd/path_manager.h
+++ b/include/mptcpd/path_manager.h
@@ -21,6 +21,21 @@ struct mptcpd_addr;
 struct mptcpd_pm;
 
 /**
+ * @brief Is mptcpd path manager ready for use?
+ *
+ * The mptcpd path manager is ready for use when the @c "mptcp"
+ * generic netlink family is available in the Linux kernel.  No
+ * path management related interaction with the kernel can occur until
+ * that family appears.
+ *
+ * @param[in] pm Mptcpd path manager.
+ *
+ * @return @c true if the mptcpd path manager is ready for use, and @c
+ *         false otherwise.
+ */
+MPTCPD_API bool mptcpd_pm_ready(struct mptcpd_pm const *pm);
+
+/**
  * @brief Send @c MPTCP_GENL_CMD_SEND_ADDR genl command to kernel.
  *
  * @param[in] pm         The mptcpd path manager object.

--- a/lib/path_manager.c
+++ b/lib/path_manager.c
@@ -97,7 +97,24 @@ static bool append_remote_addr_attr(struct l_genl_msg *msg,
         return append_addr_attr(msg, addr, local);
 }
 
+static bool is_pm_ready(struct mptcpd_pm const *pm, char const *fname)
+{
+        bool const ready = mptcpd_pm_ready(pm);
+
+        if (!ready)
+                l_warn("%s: \"" MPTCP_GENL_NAME "\" family is not "
+                       "yet available",
+                        fname);
+
+        return ready;
+}
+
 // ---------------------------------------------------------------------
+
+bool mptcpd_pm_ready(struct mptcpd_pm const *pm)
+{
+        return pm->family != NULL;
+}
 
 bool mptcpd_pm_send_addr(struct mptcpd_pm *pm,
                          mptcpd_token_t token,
@@ -105,6 +122,9 @@ bool mptcpd_pm_send_addr(struct mptcpd_pm *pm,
                          struct mptcpd_addr const *addr)
 {
         if (pm == NULL || addr == NULL)
+                return false;
+
+        if (!is_pm_ready(pm, __func__))
                 return false;
 
         assert(sizeof(addr->address.family) == sizeof(uint16_t));
@@ -180,6 +200,9 @@ bool mptcpd_pm_add_subflow(struct mptcpd_pm *pm,
                            bool backup)
 {
         if (pm == NULL)
+                return false;
+
+        if (!is_pm_ready(pm, __func__))
                 return false;
 
         /*
@@ -293,6 +316,9 @@ bool mptcpd_pm_set_backup(struct mptcpd_pm *pm,
         if (pm == NULL || local_addr == NULL || remote_addr == NULL)
                 return false;
 
+        if (!is_pm_ready(pm, __func__))
+                return false;
+
         /*
           Payload:
               Token
@@ -375,6 +401,9 @@ bool mptcpd_pm_remove_subflow(struct mptcpd_pm *pm,
                               struct mptcpd_addr const *remote_addr)
 {
         if (pm == NULL || local_addr == NULL || remote_addr == NULL)
+                return false;
+
+        if (!is_pm_ready(pm, __func__))
                 return false;
 
         /*

--- a/src/path_manager.c
+++ b/src/path_manager.c
@@ -789,8 +789,6 @@ static void family_appeared(struct l_genl_family_info const *info,
         assert(pm->family == NULL);
 
         pm->family = l_genl_family_new(pm->genl, MPTCP_GENL_NAME);
-        pm->id     = l_new(unsigned int,
-                           L_ARRAY_SIZE(pm_mcast_group_map));
 
         /*
           Register callbacks for MPTCP generic netlink multicast
@@ -885,6 +883,9 @@ struct mptcpd_pm *mptcpd_pm_create(struct mptcpd_config const *config)
                 l_error("Unable to initialize Generic Netlink system.");
                 return NULL;
         }
+
+        pm->id = l_new(unsigned int, L_ARRAY_SIZE(pm_mcast_group_map));
+
 
         if (l_genl_add_family_watch(pm->genl,
                                     MPTCP_GENL_NAME,

--- a/src/path_manager.c
+++ b/src/path_manager.c
@@ -770,6 +770,7 @@ static void handle_mptcp_event(struct l_genl_msg *msg, void *user_data)
  * available after that has happened.  Such data includes multicast
  * groups exposed by the generic netlink family, etc.
  *
+ * @param[in]     info      Generic netlink family information.
  * @param[in,out] user_data Pointer @c mptcp_pm object to which the
  *                          @c l_genl_family watch belongs.
  */
@@ -823,6 +824,7 @@ static void family_appeared(struct l_genl_family_info const *info,
 /**
  * @brief Handle MPTCP generic netlink family disappearing on us.
  *
+ * @param[in]     name      Generic netlink family name.
  * @param[in,out] user_data Pointer @c mptcp_pm object to which the
  *                          @c l_genl_family watch belongs.
  */

--- a/tests/test-commands.c
+++ b/tests/test-commands.c
@@ -10,8 +10,11 @@
 #undef NDEBUG
 #include <assert.h>
 
+#include <linux/mptcp.h>
+
 #include <ell/main.h>
-#include <ell/idle.h>
+#include <ell/genl.h>
+#include <ell/timeout.h>
 #include <ell/util.h>      // Needed by <ell/log.h>
 #include <ell/log.h>
 #include <ell/test.h>
@@ -104,49 +107,27 @@ void test_get_nm(void const *test_data)
 
 // -------------------------------------------------------------------
 
-static void idle_callback(struct l_idle *idle, void *user_data)
+static void run_tests(struct l_genl_family_info const *info,
+                      void *user_data)
 {
-        (void) idle;
+        assert(strcmp(l_genl_family_info_get_name(info),
+                      MPTCP_GENL_NAME) == 0);
+
+        l_test_run();
+
+        bool *const tests_called = user_data;
+        *tests_called = true;
+
+        l_main_quit();
+}
+
+static void timeout_callback(struct l_timeout *timeout,
+                             void *user_data)
+{
+        (void) timeout;
         (void) user_data;
 
-        /*
-          Number of ELL event loop iterations to go through before
-          triggering the MPTCP path management generic netlink command
-          calls.
-
-          This gives the mptcpd generic netlink API implementation
-          enough time for the "mptcp" generic netlink family to
-          "appear" over several ELL event loop iterations, as well as
-          the generic netlink commands to be sent.
-        */
-        static int const trigger_count = 10;
-
-        /*
-          Maximum number of ELL event loop iterations.
-
-          Stop the ELL event loop after this number of iterations.
-         */
-        static int const max_count = trigger_count * 2;
-
-        // ELL event loop iteration count.
-        static int count = 0;
-
-        static bool tests_called = false;
-
-        assert(max_count > trigger_count);  // Sanity check.
-
-        /*
-          The mptcpd network monitor interface list should now be
-          populated.  Iterate through the list, and verify that the
-          monitored interfaces are what we expect.
-         */
-        if (count > trigger_count && !tests_called) {
-                l_test_run();
-                tests_called = true;
-        }
-
-        if (++count > max_count)
-                l_main_quit();
+        l_main_quit();
 }
 
 // -------------------------------------------------------------------
@@ -165,7 +146,6 @@ int main(void)
                 TEST_PLUGIN_DIR
         };
         static char **args = argv;
-
 
         static int argc = L_ARRAY_SIZE(argv);
 
@@ -188,15 +168,37 @@ int main(void)
           Prepare to run the path management generic netlink command
           tests.
         */
-        struct l_idle *const idle =
-                l_idle_create(idle_callback, &pm, NULL);
+        bool tests_called = false;
+        struct l_genl *const genl = l_genl_new();
+        assert(genl != NULL);
+
+        assert(l_genl_add_family_watch(genl,
+                                       MPTCP_GENL_NAME,
+                                       run_tests,
+                                       NULL,
+                                       &tests_called,
+                                       NULL) != 0);
+
+        // Bound the time we wait for the tests to run.
+        static unsigned long const milliseconds = 500;
+        struct l_timeout *const timeout =
+                l_timeout_create_ms(milliseconds,
+                                    timeout_callback,
+                                    &tests_called,
+                                    NULL);
 
         (void) l_main_run();
 
+        /*
+          The tests will have run only if the "mptcp" generic netlink
+          family appeared.
+         */
+        assert(tests_called);
+
+        l_free(timeout);
+        l_genl_unref(genl);
         mptcpd_pm_destroy(pm);
         mptcpd_config_destroy(config);
-
-        l_idle_remove(idle);
 
         return l_main_exit() ? 0 : -1;
 }

--- a/tests/test-commands.c
+++ b/tests/test-commands.c
@@ -172,12 +172,15 @@ int main(void)
         struct l_genl *const genl = l_genl_new();
         assert(genl != NULL);
 
-        assert(l_genl_add_family_watch(genl,
-                                       MPTCP_GENL_NAME,
-                                       run_tests,
-                                       NULL,
-                                       &tests_called,
-                                       NULL) != 0);
+        unsigned int const watch_id =
+                l_genl_add_family_watch(genl,
+                                        MPTCP_GENL_NAME,
+                                        run_tests,
+                                        NULL,
+                                        &tests_called,
+                                        NULL);
+
+        assert(watch_id != 0);
 
         // Bound the time we wait for the tests to run.
         static unsigned long const milliseconds = 500;
@@ -195,7 +198,8 @@ int main(void)
          */
         assert(tests_called);
 
-        l_free(timeout);
+        l_timeout_remove(timeout);
+        l_genl_remove_family_watch(genl, watch_id);
         l_genl_unref(genl);
         mptcpd_pm_destroy(pm);
         mptcpd_config_destroy(config);

--- a/tests/test-commands.c
+++ b/tests/test-commands.c
@@ -26,9 +26,25 @@
 
 // -------------------------------------------------------------------
 
+static bool is_pm_ready(struct mptcpd_pm const *pm, char const *fname)
+{
+        bool const ready = mptcpd_pm_ready(pm);
+
+        if (!ready)
+                l_warn("Path manager not yet ready.  "
+                       "%s cannot be completed.", fname);
+
+        return ready;
+}
+
+// -------------------------------------------------------------------
+
 void test_send_addr(void const *test_data)
 {
         struct mptcpd_pm *const pm = (struct mptcpd_pm *) test_data;
+
+        if (!is_pm_ready(pm, __func__))
+                return;
 
         assert(mptcpd_pm_send_addr(pm,
                                    test_token_1,
@@ -39,6 +55,9 @@ void test_send_addr(void const *test_data)
 void test_add_subflow(void const *test_data)
 {
         struct mptcpd_pm *const pm = (struct mptcpd_pm *) test_data;
+
+        if (!is_pm_ready(pm, __func__))
+                return;
 
         assert(mptcpd_pm_add_subflow(pm,
                                      test_token_2,
@@ -53,6 +72,9 @@ void test_set_backup(void const *test_data)
 {
         struct mptcpd_pm *const pm = (struct mptcpd_pm *) test_data;
 
+        if (!is_pm_ready(pm, __func__))
+                return;
+
         assert(mptcpd_pm_set_backup(pm,
                                     test_token_1,
                                     &test_laddr_1,
@@ -63,6 +85,9 @@ void test_set_backup(void const *test_data)
 void test_remove_subflow(void const *test_data)
 {
         struct mptcpd_pm *const pm = (struct mptcpd_pm *) test_data;
+
+        if (!is_pm_ready(pm, __func__))
+                return;
 
         assert(mptcpd_pm_remove_subflow(pm,
                                         test_token_1,

--- a/tests/test-path-manager.c
+++ b/tests/test-path-manager.c
@@ -19,6 +19,7 @@
 #include "../src/configuration.h"        // INTERNAL!
 #include "../src/path_manager.h"         // INTERNAL!
 #include <mptcpd/path_manager_private.h> // INTERNAL!
+#include <mptcpd/path_manager.h>
 
 // -------------------------------------------------------------------
 
@@ -39,14 +40,22 @@ void test_pm_create(void const *test_data)
 
         assert(info->pm         != NULL);
         assert(info->pm->genl   != NULL);
-        assert(info->pm->id     != NULL);
-        assert(info->pm->family != NULL);
         assert(info->pm->nm     != NULL);
+
+        /*
+          Other struct mptcpd_pm fields may not have been initialized
+          yet since they depend on the existence of the "mptcpd"
+          generic netlink family.
+        */
 }
 
 void test_pm_destroy(void const *test_data)
 {
         struct test_info *const info = (struct test_info *) test_data;
+
+        if (!mptcpd_pm_ready(info->pm))
+                l_warn("Path manager was not ready.  "
+                       "Test was likely limited.");
 
         mptcpd_pm_destroy(info->pm);
 }

--- a/tests/test-path-manager.c
+++ b/tests/test-path-manager.c
@@ -126,12 +126,15 @@ int main(void)
         struct l_genl *const genl = l_genl_new();
         assert(genl != NULL);
 
-        assert(l_genl_add_family_watch(genl,
-                                       MPTCP_GENL_NAME,
-                                       run_tests,
-                                       NULL,
-                                       &info,
-                                       NULL) != 0);
+        unsigned int const watch_id =
+                l_genl_add_family_watch(genl,
+                                        MPTCP_GENL_NAME,
+                                        run_tests,
+                                        NULL,
+                                        &info,
+                                        NULL);
+
+        assert(watch_id != 0);
 
         // Bound the time we wait for the tests to run.
         static unsigned long const milliseconds = 500;
@@ -149,7 +152,8 @@ int main(void)
          */
         assert(info.tests_called);
 
-        l_free(timeout);
+        l_timeout_remove(timeout);
+        l_genl_remove_family_watch(genl, watch_id);
         l_genl_unref(genl);
         mptcpd_config_destroy(info.config);
 


### PR DESCRIPTION
The ELL generic netlink API was changed in a non-backward compatible way in the upcoming 0.21 release.  Update mptcpd to use new ELL generic netlink API.
    
The update slightly modifies behavior so that a l_genl_family object  used for interactions with the kernel cannot be allocated until the  generic netlink family, "`mptcp`" is this case, appears.  This isn't a  major change, but it will affect some of the mptcpd tests.
