### PR TITLE
Use -Og for debugger-friendly optimization

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -152,7 +152,7 @@ AS_IF([test "x$ax_enable_debug" != "xyes"],
       [
        dnl Minimal optimization for the debug case.  We need this for
        dnl _FORTIFY_SOURCE support, too.
-       MPTCPD_ADD_COMPILE_FLAG([-O])
+       MPTCPD_ADD_COMPILE_FLAG([-Og])
       ])
 
 dnl Export symbols in the public API from shared libraries.

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -185,7 +185,7 @@ test_cxx_build_CPPFLAGS =				\
 	-I$(top_srcdir)/include				\
 	-DTEST_PLUGIN_DIR=\"$(TEST_PLUGIN_DIR_A)\"	\
 	-DTEST_PLUGIN_FOUR=\"$(TEST_PLUGIN_FOUR)\"
-test_cxx_build_CXXFLAGS = $(AM_CFLAGS)
+test_cxx_build_CXXFLAGS = $(AM_CFLAGS) -Og
 test_cxx_build_LDADD =				\
 	$(top_builddir)/lib/libmptcpd.la	\
 	libmptcpd_test.la			\


### PR DESCRIPTION
This optimization flag (in gcc 4.8 and later) is gdb-friendly and satisfies optimizer requirements for _FORTIFY_SOURCE.