### PR TITLE
src: Warn on incorrect run-time kernel config.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -190,6 +190,19 @@ AC_SEARCH_LIBS(
     [AC_MSG_ERROR([library with argp_parse() could not be found])])
 
 # ---------------------------------------------------------------
+# Checks for declaration.
+# ---------------------------------------------------------------
+AC_CHECK_DECLS([IPPROTO_MPTCP],
+               [],
+	       [AC_MSG_WARN([IPPROTO_MPTCP declaration not found.  Using fallback.])],
+	       [[
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <linux/in.h>
+	       ]])
+
+# ---------------------------------------------------------------
 # Enable additional C compiler warnings.  We do this after all
 # Autoconf tests have been run since not all autoconf macros are
 # warning free.

--- a/include/mptcpd/path_manager_private.h
+++ b/include/mptcpd/path_manager_private.h
@@ -16,7 +16,7 @@ extern "C" {
 
 struct l_genl;
 struct l_genl_family;
-struct l_hashmap;
+struct l_timeout;
 
 struct mptcpd_nm;
 
@@ -44,6 +44,15 @@ struct mptcpd_pm
          * MPTCP family in the kernel.
          */
         struct l_genl_family *family;
+
+        /**
+         * @brief @c "mptcp" generic netlink family timeout object.
+         *
+         * The timeout used to warn the user if the @c "mptcp" generic
+         * netlink family needed by mptcpd does not appear within a
+         * certain amount of time.
+         */
+        struct l_timeout *timeout;
 
         /**
          * @brief Network device monitor.

--- a/src/path_manager.c
+++ b/src/path_manager.c
@@ -754,6 +754,9 @@ static void handle_mptcp_event(struct l_genl_msg *msg, void *user_data)
  *
  * Check that MPTCP is supported in the kernel by opening a socket
  * with the @c IPPROTO_MPTCP protocol.
+ *
+ * @note @c IPPROTO_MPTCP is supported by the "MPTCP upstream"
+ *       kernel.
  */
 static bool check_mptcp_socket_support(void)
 {
@@ -777,6 +780,9 @@ static bool check_mptcp_socket_support(void)
  *
  * Check that MPTCP is enabled through the @c net.mptcp.mptcp_enabled
  * @c sysctl variable if it exists.
+ *
+ * @note The @c net.mptcp.mptcp_enabled is supported by the
+ *       multipath-tcp.org kernel.
  */
 static bool check_kernel_mptcp_enabled(void)
 {

--- a/src/path_manager.c
+++ b/src/path_manager.c
@@ -767,12 +767,14 @@ static bool check_mptcp_socket_support(void)
         int const fd = socket(AF_INET, SOCK_STREAM, IPPROTO_MPTCP);
 
         // An errno other than EINVAL is unexpected.
-        if (fd != -1)
+        if (fd != -1) {
                 close(fd);
-        else if (errno != EINVAL)
+                return true;
+        } else if (errno != EINVAL) {
                 l_error("Unable to confirm MPTCP socket support.");
+        }
 
-        return fd != -1;
+        return false;
 }
 
 /**

--- a/src/path_manager.c
+++ b/src/path_manager.c
@@ -753,7 +753,7 @@ static void handle_mptcp_event(struct l_genl_msg *msg, void *user_data)
  * @brief Verify that MPTCP is enabled at run-time in the kernel.
  *
  * Check that MPTCP is supported in the kernel by opening a socket
- * with the IPPROTO_MPTCP protocol.
+ * with the @c IPPROTO_MPTCP protocol.
  */
 static bool check_mptcp_socket_support(void)
 {
@@ -763,9 +763,8 @@ static bool check_mptcp_socket_support(void)
 
         int const fd = socket(AF_INET, SOCK_STREAM, IPPROTO_MPTCP);
 
-        if (fd == -1
-            && errno != EPROTONOSUPPORT
-            && errno != EINVAL)
+        // An errno other than EINVAL is unexpected.
+        if (fd == -1 && errno != EINVAL)
                 l_error("Unable to confirm MPTCP socket support.");
 
         close(fd);

--- a/src/path_manager.c
+++ b/src/path_manager.c
@@ -767,11 +767,10 @@ static bool check_mptcp_socket_support(void)
         int const fd = socket(AF_INET, SOCK_STREAM, IPPROTO_MPTCP);
 
         // An errno other than EINVAL is unexpected.
-        if (fd == -1 && errno != EINVAL)
-                l_error("Unable to confirm MPTCP socket support.");
-
         if (fd != -1)
                 close(fd);
+        else if (errno != EINVAL)
+                l_error("Unable to confirm MPTCP socket support.");
 
         return fd != -1;
 }

--- a/src/path_manager.c
+++ b/src/path_manager.c
@@ -801,7 +801,7 @@ static bool check_kernel_mptcp_enabled(void)
 
         fclose(f);
 
-        if (likely(n == 1)) {
+        if (n == 1) {
                 // "enabled" could be 0, 1, or 2.
                 enabled = (enabled == 1 || enabled == 2);
 

--- a/src/path_manager.c
+++ b/src/path_manager.c
@@ -799,9 +799,13 @@ static void check_kernel_mptcp_path_manager(void)
                 return;  // Not using multipath-tcp.org kernel.
 
         char pm[MPTCP_PM_NAME_MAX + 1] = { 0 };
-        char const *const s = fgets(pm, sizeof(pm), f);
 
-        if (likely(s != NULL)) {
+        static char const MPTCP_PM_NAME_FMT[] =
+                "%" L_STRINGIFY(MPTCP_PM_NAME_MAX) "s";
+
+        int const n = fscanf(f, MPTCP_PM_NAME_FMT, pm);
+
+        if (likely(n == 1)) {
                 if (strcmp(pm, "netlink") != 0) {
                         /*
                           "netlink" could be set as the default.  It

--- a/src/path_manager.c
+++ b/src/path_manager.c
@@ -770,7 +770,8 @@ static bool check_mptcp_socket_support(void)
         if (fd == -1 && errno != EINVAL)
                 l_error("Unable to confirm MPTCP socket support.");
 
-        close(fd);
+        if (fd != -1)
+                close(fd);
 
         return fd != -1;
 }


### PR DESCRIPTION
Issue a warning if the [multipath-tcp.org](https://multipath-tcp.org/) kernel is not [configured](http://multipath-tcp.org/pmwiki.php/Users/ConfigureMPTCP) at run-time in a manner suitable for mptcpd.  See #36 for further discussion.