### PR TITLE
path_manager: Only track one genl multicast group.

### DIFF
--- a/include/mptcpd/path_manager_private.h
+++ b/include/mptcpd/path_manager_private.h
@@ -34,15 +34,8 @@ struct mptcpd_pm
         /// Core ELL generic netlink object.
         struct l_genl *genl;
 
-        /**
-         * @brief Array of MPTCP generic netlink multicast
-         *        notification IDs.
-         *
-         * @todo It is unlikely that we'll ever need to support more than one
-         *       generic netlink multicast group.  Consider replacing
-         *       this array with single, non-pointer, integer value.
-         */
-        unsigned int *id;
+        /// MPTCP generic netlink multicast notification ID.
+        unsigned int id;
 
         /**
          * @brief MPTCP generic netlink family.


### PR DESCRIPTION
Only one multicast group, "mptcp_events", in the generic netlink
"mptcp" family is used by mptcpd.  There is no need to track multiple
group IDs.  Drop the multicast group ID array, and replace it with
single scalar variable.