### PR TITLE
path_manager: Explicitly request "mptcp" family.

### DIFF
--- a/tests/test-commands.c
+++ b/tests/test-commands.c
@@ -181,13 +181,6 @@ int main(void)
         struct l_genl *const genl = l_genl_new();
         assert(genl != NULL);
 
-        bool const requested = l_genl_request_family(genl,
-                                                     MPTCP_GENL_NAME,
-                                                     run_tests,
-                                                     &tests_called,
-                                                     NULL);
-        assert(requested);
-
         unsigned int const watch_id =
                 l_genl_add_family_watch(genl,
                                         MPTCP_GENL_NAME,
@@ -197,6 +190,13 @@ int main(void)
                                         NULL);
 
         assert(watch_id != 0);
+
+        bool const requested = l_genl_request_family(genl,
+                                                     MPTCP_GENL_NAME,
+                                                     run_tests,
+                                                     &tests_called,
+                                                     NULL);
+        assert(requested);
 
         // Bound the time we wait for the tests to run.
         static unsigned long const milliseconds = 500;

--- a/tests/test-path-manager.c
+++ b/tests/test-path-manager.c
@@ -137,13 +137,6 @@ int main(void)
         struct l_genl *const genl = l_genl_new();
         assert(genl != NULL);
 
-        bool const requested = l_genl_request_family(genl,
-                                                     MPTCP_GENL_NAME,
-                                                     run_tests,
-                                                     &info,
-                                                     NULL);
-        assert(requested);
-
         unsigned int const watch_id =
                 l_genl_add_family_watch(genl,
                                         MPTCP_GENL_NAME,
@@ -153,6 +146,13 @@ int main(void)
                                         NULL);
 
         assert(watch_id != 0);
+
+        bool const requested = l_genl_request_family(genl,
+                                                     MPTCP_GENL_NAME,
+                                                     run_tests,
+                                                     &info,
+                                                     NULL);
+        assert(requested);
 
         // Bound the time we wait for the tests to run.
         static unsigned long const milliseconds = 500;


### PR DESCRIPTION
With the new ELL generic netlink API, it is no longer enough to simply
set a watch for the "mptcp" generic netlink family since the watch is
only triggered on a family change (appeared or vanished).  If the
family already existed prior to mptcpd start the watch won't be
triggered.  Explicitly request the "mptcp" family, and only bother
setting a watch if that request failed.  Fixes a problem where the
mptcpd would not fully initialize it's path manager bridge component.