### PR TITLE
configure: Require ELL >= 0.21.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -161,7 +161,7 @@ AM_CONDITIONAL([BUILDING_DLL], [test "x$enable_shared" = xyes])
 # ---------------------------------------------------------------
 # Checks for libraries.
 # ---------------------------------------------------------------
-PKG_CHECK_MODULES([ELL], [ell >= 0.17])
+PKG_CHECK_MODULES([ELL], [ell >= 0.21])
 
 # ---------------------------------------------------------------
 # Checks for header files.


### PR DESCRIPTION
ELL's new genl API, which mptcpd requires, was made available in ELL
0.21.  Update the corresponding configure script check accordingly.