### PR TITLE
Correct issues flagged by clang-tidy.

### DIFF
--- a/lib/network_monitor.c
+++ b/lib/network_monitor.c
@@ -259,7 +259,7 @@ mptcpd_interface_create(struct ifinfomsg const *ifi, uint32_t len)
         interface->index  = ifi->ifi_index;
         interface->flags  = ifi->ifi_flags;
 
-        int bytes = len - NLMSG_ALIGN(sizeof(*ifi));
+        size_t bytes = len - NLMSG_ALIGN(sizeof(*ifi));
 
         /**
          * @todo Can we retrieve the IP address associated with each
@@ -695,7 +695,7 @@ static void foreach_ifaddr(struct ifaddrmsg const *ifa,
         assert(addrs != NULL);
         assert(handler != NULL);
 
-        int bytes = len - NLMSG_ALIGN(sizeof(*ifa));
+        size_t bytes = len - NLMSG_ALIGN(sizeof(*ifa));
 
         for (struct rtattr const *rta = IFA_RTA(ifa);
              RTA_OK(rta, bytes);

--- a/src/path_manager.c
+++ b/src/path_manager.c
@@ -87,10 +87,10 @@ static bool validate_attr_len(size_t actual, size_t expected)
  * @param[in]  len  Length (size) of attribute data.
  * @param[out] attr Pointer to attribute data destination.
  */
-#define MPTCP_GET_NL_ATTR(data, len, attr)                  \
-        do {                                                \
-                if (validate_attr_len(len, sizeof(*attr)))  \
-                        attr = data;                        \
+#define MPTCP_GET_NL_ATTR(data, len, attr)                      \
+        do {                                                    \
+                if (validate_attr_len(len, sizeof(*(attr))))    \
+                        (attr) = data;                          \
         } while(0)
 
 #ifdef MPTCPD_ENABLE_PM_NAME


### PR DESCRIPTION
Fix minor issues flagged by the [clang-tidy](https://clang.llvm.org/extra/clang-tidy/) tool, such as bug prone casts, and missing parenthesis around macro arguments.