### PR TITLE
Move private plugin API to a separate file.

### DIFF
--- a/include/mptcpd/Makefile.am
+++ b/include/mptcpd/Makefile.am
@@ -11,4 +11,5 @@ pkginclude_HEADERS =		\
 
 noinst_HEADERS =		\
 	config-private.h	\
-	path_manager_private.h
+	path_manager_private.h 	\
+	plugin_private.h

--- a/include/mptcpd/path_manager_private.h
+++ b/include/mptcpd/path_manager_private.h
@@ -2,7 +2,7 @@
 /**
  * @file path_manager_private.h
  *
- * @brief mptcpd user space path manager plugin header file.
+ * @brief mptcpd path manager private interface.
  *
  * Copyright (c) 2017-2019, Intel Corporation
  */

--- a/include/mptcpd/plugin.h
+++ b/include/mptcpd/plugin.h
@@ -20,10 +20,10 @@ extern "C" {
 #endif
 
 /**
- * @brief Mptcpd plugin "@a symbol" argument for @c L_PLUGIN_DEFINE.
+ * @brief Mptcpd plugin @a "symbol" argument for @c L_PLUGIN_DEFINE.
  *
  * All mptcpd plugins are expected to use this value as the @a symbol
- * argument in their L_PLUGIN_DEFINE() macro call.
+ * argument in their @c L_PLUGIN_DEFINE() macro call.
  */
 #define MPTCPD_PLUGIN_DESC mptcpd_plugin_desc
 
@@ -169,23 +169,6 @@ struct mptcpd_plugin_ops
 };
 
 /**
- * @brief Load mptcpd plugins.
- *
- * @param[in] dir          Directory from which plugins will be loaded.
- * @param[in] default_name Name of plugin to be considered the
- *                         default.
- *
- * @return @c true on successful load, @c false otherwise.
- */
-MPTCPD_API bool mptcpd_plugin_load(char const *dir,
-                                   char const *default_name);
-
-/**
- * @brief Unload mptcpd plugins.
- */
-MPTCPD_API void mptcpd_plugin_unload(void);
-
-/**
  * @brief Register path manager operations.
  *
  * Path manager plugins should call this function to register their
@@ -201,118 +184,6 @@ MPTCPD_API void mptcpd_plugin_unload(void);
 MPTCPD_API bool mptcpd_plugin_register_ops(
         char const *name,
         struct mptcpd_plugin_ops const *ops);
-
-/**
- * @brief Notify plugin of new MPTCP connection pending completion.
- *
- * @param[in] name   Plugin name.
- * @param[in] token  MPTCP connection token.
- * @param[in] laddr  Local address information.
- * @param[in] raddr  Remote address information.
- * @param[in] pm     Opaque pointer to mptcpd path manager object.
- */
-MPTCPD_API void mptcpd_plugin_new_connection(
-        char const *name,
-        mptcpd_token_t token,
-        struct sockaddr const *laddr,
-        struct sockaddr const *raddr,
-        struct mptcpd_pm *pm);
-
-/**
- * @brief Notify plugin of MPTCP connection completion.
- *
- * @param[in] token  MPTCP connection token.
- * @param[in] laddr  Local address information.
- * @param[in] raddr  Remote address information.
- * @param[in] pm     Opaque pointer to mptcpd path manager object.
- */
-MPTCPD_API void mptcpd_plugin_connection_established(
-        mptcpd_token_t token,
-        struct sockaddr const *laddr,
-        struct sockaddr const *raddr,
-        struct mptcpd_pm *pm);
-
-/**
- * @brief Notify plugin of MPTCP connection closure.
- *
- * @param[in] token MPTCP connection token.
- * @param[in] pm    Opaque pointer to mptcpd path manager object.
- */
-MPTCPD_API void mptcpd_plugin_connection_closed(
-        mptcpd_token_t token,
-        struct mptcpd_pm *pm);
-
-/**
- * @brief Notify plugin of new address advertised by a peer.
- *
- * @param[in] token MPTCP connection token.
- * @param[in] id    Remote address identifier.
- * @param[in] addr  Remote address information.
- * @param[in] pm    Opaque pointer to mptcpd path manager object.
- */
-MPTCPD_API void mptcpd_plugin_new_address(mptcpd_token_t token,
-                                          mptcpd_aid_t id,
-                                          struct sockaddr const *addr,
-                                          struct mptcpd_pm *pm);
-
-/**
- * @brief Notify plugin of address no longer advertised by a peer.
- *
- * @param[in] token MPTCP connection token.
- * @param[in] id    Remote address identifier.
- * @param[in] pm    Opaque pointer to mptcpd path manager object.
- */
-MPTCPD_API void mptcpd_plugin_address_removed(mptcpd_token_t token,
-                                              mptcpd_aid_t id,
-                                              struct mptcpd_pm *pm);
-
-/**
- * @brief Notify plugin that a peer has joined the MPTCP connection.
- *
- * @param[in] token  MPTCP connection token.
- * @param[in] laddr  Local address information.
- * @param[in] raddr  Remote address information.
- * @param[in] backup Backup priority flag.
- * @param[in] pm     Opaque pointer to mptcpd path manager object.
- */
-MPTCPD_API void mptcpd_plugin_new_subflow(
-        mptcpd_token_t token,
-        struct sockaddr const *laddr,
-        struct sockaddr const *raddr,
-        bool backup,
-        struct mptcpd_pm *pm);
-
-/**
- * @brief Notify plugin of MPTCP subflow closure.
- *
- * @param[in] token  MPTCP connection token.
- * @param[in] laddr  Local address information.
- * @param[in] raddr  Remote address information.
- * @param[in] backup Backup priority flag.
- * @param[in] pm     Opaque pointer to mptcpd path manager object.
- */
-MPTCPD_API void mptcpd_plugin_subflow_closed(
-        mptcpd_token_t token,
-        struct sockaddr const *laddr,
-        struct sockaddr const *raddr,
-        bool backup,
-        struct mptcpd_pm *pm);
-
-/**
- * @brief Notify plugin of MPTCP subflow priority change.
- *
- * @param[in] token  MPTCP connection token.
- * @param[in] laddr  Local address information.
- * @param[in] raddr  Remote address information.
- * @param[in] backup Backup priority flag.
- * @param[in] pm     Opaque pointer to mptcpd path manager object.
- */
-MPTCPD_API void mptcpd_plugin_subflow_priority(
-        mptcpd_token_t token,
-        struct sockaddr const *laddr,
-        struct sockaddr const *raddr,
-        bool backup,
-        struct mptcpd_pm *pm);
 
 #ifdef __cplusplus
 }

--- a/include/mptcpd/plugin_private.h
+++ b/include/mptcpd/plugin_private.h
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/**
+ * @file plugin_private.h
+ *
+ * @brief mptcpd private plugin interface.
+ *
+ * Copyright (c) 2017-2019, Intel Corporation
+ */
+
+#ifndef MPTCPD_PLUGIN_PRIVATE_H
+#define MPTCPD_PLUGIN_PRIVATE_H
+
+#include <stdbool.h>
+
+#include <mptcpd/export.h>
+#include <mptcpd/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct sockaddr;
+struct mptcpd_pm;
+
+/**
+ * @brief Load mptcpd plugins.
+ *
+ * @param[in] dir          Directory from which plugins will be loaded.
+ * @param[in] default_name Name of plugin to be considered the
+ *                         default.
+ *
+ * @return @c true on successful load, @c false otherwise.
+ */
+MPTCPD_API bool mptcpd_plugin_load(char const *dir,
+                                   char const *default_name);
+
+/**
+ * @brief Unload mptcpd plugins.
+ */
+MPTCPD_API void mptcpd_plugin_unload(void);
+
+/**
+ * @brief Notify plugin of new MPTCP connection pending completion.
+ *
+ * @param[in] name   Plugin name.
+ * @param[in] token  MPTCP connection token.
+ * @param[in] laddr  Local address information.
+ * @param[in] raddr  Remote address information.
+ * @param[in] pm     Opaque pointer to mptcpd path manager object.
+ */
+MPTCPD_API void mptcpd_plugin_new_connection(
+        char const *name,
+        mptcpd_token_t token,
+        struct sockaddr const *laddr,
+        struct sockaddr const *raddr,
+        struct mptcpd_pm *pm);
+
+/**
+ * @brief Notify plugin of MPTCP connection completion.
+ *
+ * @param[in] token  MPTCP connection token.
+ * @param[in] laddr  Local address information.
+ * @param[in] raddr  Remote address information.
+ * @param[in] pm     Opaque pointer to mptcpd path manager object.
+ */
+MPTCPD_API void mptcpd_plugin_connection_established(
+        mptcpd_token_t token,
+        struct sockaddr const *laddr,
+        struct sockaddr const *raddr,
+        struct mptcpd_pm *pm);
+
+/**
+ * @brief Notify plugin of MPTCP connection closure.
+ *
+ * @param[in] token MPTCP connection token.
+ * @param[in] pm    Opaque pointer to mptcpd path manager object.
+ */
+MPTCPD_API void mptcpd_plugin_connection_closed(
+        mptcpd_token_t token,
+        struct mptcpd_pm *pm);
+
+/**
+ * @brief Notify plugin of new address advertised by a peer.
+ *
+ * @param[in] token MPTCP connection token.
+ * @param[in] id    Remote address identifier.
+ * @param[in] addr  Remote address information.
+ * @param[in] pm    Opaque pointer to mptcpd path manager object.
+ */
+MPTCPD_API void mptcpd_plugin_new_address(mptcpd_token_t token,
+                                          mptcpd_aid_t id,
+                                          struct sockaddr const *addr,
+                                          struct mptcpd_pm *pm);
+
+/**
+ * @brief Notify plugin of address no longer advertised by a peer.
+ *
+ * @param[in] token MPTCP connection token.
+ * @param[in] id    Remote address identifier.
+ * @param[in] pm    Opaque pointer to mptcpd path manager object.
+ */
+MPTCPD_API void mptcpd_plugin_address_removed(mptcpd_token_t token,
+                                              mptcpd_aid_t id,
+                                              struct mptcpd_pm *pm);
+
+/**
+ * @brief Notify plugin that a peer has joined the MPTCP connection.
+ *
+ * @param[in] token  MPTCP connection token.
+ * @param[in] laddr  Local address information.
+ * @param[in] raddr  Remote address information.
+ * @param[in] backup Backup priority flag.
+ * @param[in] pm     Opaque pointer to mptcpd path manager object.
+ */
+MPTCPD_API void mptcpd_plugin_new_subflow(
+        mptcpd_token_t token,
+        struct sockaddr const *laddr,
+        struct sockaddr const *raddr,
+        bool backup,
+        struct mptcpd_pm *pm);
+
+/**
+ * @brief Notify plugin of MPTCP subflow closure.
+ *
+ * @param[in] token  MPTCP connection token.
+ * @param[in] laddr  Local address information.
+ * @param[in] raddr  Remote address information.
+ * @param[in] backup Backup priority flag.
+ * @param[in] pm     Opaque pointer to mptcpd path manager object.
+ */
+MPTCPD_API void mptcpd_plugin_subflow_closed(
+        mptcpd_token_t token,
+        struct sockaddr const *laddr,
+        struct sockaddr const *raddr,
+        bool backup,
+        struct mptcpd_pm *pm);
+
+/**
+ * @brief Notify plugin of MPTCP subflow priority change.
+ *
+ * @param[in] token  MPTCP connection token.
+ * @param[in] laddr  Local address information.
+ * @param[in] raddr  Remote address information.
+ * @param[in] backup Backup priority flag.
+ * @param[in] pm     Opaque pointer to mptcpd path manager object.
+ */
+MPTCPD_API void mptcpd_plugin_subflow_priority(
+        mptcpd_token_t token,
+        struct sockaddr const *laddr,
+        struct sockaddr const *raddr,
+        bool backup,
+        struct mptcpd_pm *pm);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // MPTCPD_PLUGIN_PRIVATE_H
+
+
+/*
+  Local Variables:
+  c-file-style: "linux"
+  End:
+*/

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -22,6 +22,7 @@
 #include <mptcpd/config-private.h>
 #endif
 
+#include <mptcpd/plugin_private.h>
 #include <mptcpd/plugin.h>
 
 /**

--- a/src/path_manager.c
+++ b/src/path_manager.c
@@ -28,7 +28,7 @@
 #include <ell/util.h>
 
 #include <mptcpd/path_manager_private.h>
-#include <mptcpd/plugin.h>
+#include <mptcpd/plugin_private.h>
 #include <mptcpd/network_monitor.h>
 
 #ifdef HAVE_CONFIG_H

--- a/tests/call_plugin.c
+++ b/tests/call_plugin.c
@@ -10,7 +10,7 @@
 #include <assert.h>
 #include <stdlib.h>
 
-#include <mptcpd/plugin.h>
+#include <mptcpd/plugin_private.h>
 
 #include "test-plugin.h"
 

--- a/tests/test-cxx-build.cpp
+++ b/tests/test-cxx-build.cpp
@@ -21,6 +21,8 @@
 #include <mptcpd/network_monitor.h>
 #include <mptcpd/plugin.h>
 
+#include <mptcpd/plugin_private.h>
+
 #include "test-plugin.h"
 
 /**

--- a/tests/test-plugin.c
+++ b/tests/test-plugin.c
@@ -19,7 +19,7 @@
 
 #include <ell/test.h>
 
-#include <mptcpd/plugin.h>
+#include <mptcpd/plugin_private.h>
 
 #include "test-plugin.h"
 


### PR DESCRIPTION
The `libmptcpd` library exposes an API that is meant solely for use by the `mptcpd` program, not plugins.  Move functions in the private plugin API to a new `<mptcpd/plugin_private.h>` header that doesn't get installed.
