### PR TITLE
network_monitor: Fix netlink related memory leak.

### DIFF
--- a/lib/network_monitor.c
+++ b/lib/network_monitor.c
@@ -893,6 +893,13 @@ static void send_getaddr_command(void *user_data)
 {
         struct mptcpd_nm *const nm = user_data;
 
+        /*
+          Don't bother attempting to retrieve IP addresses if no
+          network interfaces are being tracked.
+         */
+        if (l_queue_isempty(nm->interfaces))
+                return;
+
         // Get IP addresses.
         struct ifaddrmsg addr_msg = { .ifa_family = AF_UNSPEC };
         if (l_netlink_send(nm->rtnl,
@@ -1021,6 +1028,7 @@ void mptcpd_nm_destroy(struct mptcpd_nm *nm)
                 l_error("Failed to unregister IPv6 monitor.");
 
         l_queue_destroy(nm->interfaces, mptcpd_interface_destroy);
+        nm->interfaces = NULL;
 
         l_netlink_destroy(nm->rtnl);
         l_free(nm);

--- a/src/path_manager.c
+++ b/src/path_manager.c
@@ -1042,19 +1042,6 @@ struct mptcpd_pm *mptcpd_pm_create(struct mptcpd_config const *config)
                 return NULL;
         }
 
-        /**
-         * @bug Mptcpd plugins should only be loaded once at process
-         *      start.  The @c mptcpd_plugin_load() function only
-         *      loads the functions once, and only reloads after
-         *      @c mptcpd_plugin_unload() is called.
-         */
-        if (!mptcpd_plugin_load(config->plugin_dir,
-                                config->default_plugin)) {
-                l_error("Unable to load path manager plugins.");
-
-                return NULL;
-        }
-
         struct mptcpd_pm *const pm = l_new(struct mptcpd_pm, 1);
 
         // No need to check for NULL.  l_new() abort()s on failure.
@@ -1109,6 +1096,19 @@ struct mptcpd_pm *mptcpd_pm_create(struct mptcpd_config const *config)
                 return NULL;
         }
 
+        /**
+         * @bug Mptcpd plugins should only be loaded once at process
+         *      start.  The @c mptcpd_plugin_load() function only
+         *      loads the functions once, and only reloads after
+         *      @c mptcpd_plugin_unload() is called.
+         */
+        if (!mptcpd_plugin_load(config->plugin_dir,
+                                config->default_plugin)) {
+                l_error("Unable to load path manager plugins.");
+
+                return NULL;
+        }
+
         return pm;
 }
 
@@ -1117,18 +1117,18 @@ void mptcpd_pm_destroy(struct mptcpd_pm *pm)
         if (pm == NULL)
                 return;
 
-        mptcpd_nm_destroy(pm->nm);
-        l_timeout_remove(pm->timeout);
-        l_genl_family_free(pm->family);
-        l_genl_unref(pm->genl);
-        l_free(pm);
-
         /**
          * @bug Mptcpd plugins should only be unloaded once at process
          *      exit, or at least after the last @c mptcpd_pm object
          *      has been destroyed.
          */
         mptcpd_plugin_unload();
+
+        mptcpd_nm_destroy(pm->nm);
+        l_timeout_remove(pm->timeout);
+        l_genl_family_free(pm->family);
+        l_genl_unref(pm->genl);
+        l_free(pm);
 }
 
 

--- a/src/path_manager.c
+++ b/src/path_manager.c
@@ -1042,6 +1042,19 @@ struct mptcpd_pm *mptcpd_pm_create(struct mptcpd_config const *config)
                 return NULL;
         }
 
+        /**
+         * @bug Mptcpd plugins should only be loaded once at process
+         *      start.  The @c mptcpd_plugin_load() function only
+         *      loads the functions once, and only reloads after
+         *      @c mptcpd_plugin_unload() is called.
+         */
+        if (!mptcpd_plugin_load(config->plugin_dir,
+                                config->default_plugin)) {
+                l_error("Unable to load path manager plugins.");
+
+                return NULL;
+        }
+
         struct mptcpd_pm *const pm = l_new(struct mptcpd_pm, 1);
 
         // No need to check for NULL.  l_new() abort()s on failure.
@@ -1096,19 +1109,6 @@ struct mptcpd_pm *mptcpd_pm_create(struct mptcpd_config const *config)
                 return NULL;
         }
 
-        /**
-         * @bug Mptcpd plugins should only be loaded once at process
-         *      start.  The @c mptcpd_plugin_load() function only
-         *      loads the functions once, and only reloads after
-         *      @c mptcpd_plugin_unload() is called.
-         */
-        if (!mptcpd_plugin_load(config->plugin_dir,
-                                config->default_plugin)) {
-                l_error("Unable to load path manager plugins.");
-
-                return NULL;
-        }
-
         return pm;
 }
 
@@ -1117,18 +1117,18 @@ void mptcpd_pm_destroy(struct mptcpd_pm *pm)
         if (pm == NULL)
                 return;
 
+        mptcpd_nm_destroy(pm->nm);
+        l_timeout_remove(pm->timeout);
+        l_genl_family_free(pm->family);
+        l_genl_unref(pm->genl);
+        l_free(pm);
+
         /**
          * @bug Mptcpd plugins should only be unloaded once at process
          *      exit, or at least after the last @c mptcpd_pm object
          *      has been destroyed.
          */
         mptcpd_plugin_unload();
-
-        mptcpd_nm_destroy(pm->nm);
-        l_timeout_remove(pm->timeout);
-        l_genl_family_free(pm->family);
-        l_genl_unref(pm->genl);
-        l_free(pm);
 }
 
 


### PR DESCRIPTION
Fix a memory leak that occurred when destroying a network monitor
instance that hasn't been fully initialized.  In particular, do not
attempt to retrieve network addresses if network interfaces are not
being tracked by the mptcpd network monitor.

The memory leak was caused by an incomplete attempt to retrieve
network addresses during mptcpd network monitor destruction.  Network
address retrieval is not necessary during mptcpd network monitor
destruction, but is unnecessarily triggered because of an ELL related
workaround that forces network address retrieval through the rtnetlink
API to occur only after network interface retrieval completes by
leveraging the netlink command "destroy" function as the trigger for
address retrieval.

Fixes #17.