### PR TITLE
Add pkg-config support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ mptcpd-*/
 core*
 doc/
 etc/*.conf
+lib/mptcpd.pc
 src/mptcpd
 src/mptcp.service
 man/mptcpd.8

--- a/configure.ac
+++ b/configure.ac
@@ -265,6 +265,7 @@ AC_CONFIG_FILES([Makefile
                  include/linux/Makefile
                  include/mptcpd/Makefile
                  lib/Makefile
+                 lib/mptcpd.pc
                  src/Makefile
                  plugins/Makefile
                  plugins/path_managers/Makefile

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -27,4 +27,7 @@ libmptcpd_la_SOURCES =		\
 #libmptcpd_la_SOURCES += debug.c
 #endif
 
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = mptcpd.pc
+
 clean-local: code-coverage-clean

--- a/lib/mptcpd.pc.in
+++ b/lib/mptcpd.pc.in
@@ -1,8 +1,18 @@
+# Basic package variables.
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
 
+# Mptcpd package library directory.
+#
+# This corresponds to the default plugin directory set when mptcpd was
+# built.  It may differ from the actual site-specific plugin directory
+# if the default directory was overridden in the mptcpd configuration
+# file or on the command line.
+pkglibdir=@libdir@/@PACKAGE@
+
+# Package keywords.
 Name: @PACKAGE_NAME@
 Description: The Multipath TCP Daemon library
 URL: @PACKAGE_URL@

--- a/lib/mptcpd.pc.in
+++ b/lib/mptcpd.pc.in
@@ -1,0 +1,12 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: @PACKAGE_NAME@
+Description: The Multipath TCP Daemon library
+URL: @PACKAGE_URL@
+Version: @VERSION@
+Requires.private: ell >= 0.21
+Cflags: -I${includedir}
+Libs: -L${libdir} -lmptcpd


### PR DESCRIPTION
Generate a `mptcpd.pc' pkg-config file that may be used by mptcpd
plugin developers to obtain the necessary mptcpd build related
information.