### PR TITLE
Do not log MPTCP connection token.

### DIFF
--- a/include/mptcpd/types.h
+++ b/include/mptcpd/types.h
@@ -28,10 +28,27 @@ typedef uint32_t mptcpd_token_t;
 typedef uint8_t mptcpd_aid_t;
 
 /// MPTCP connection token format specifier.
-#define MPTCPD_PRIxTOKEN PRIx32
+#define MPTCPD_PRIxTOKEN "#010" PRIx32
 
 /// MPTCP address ID format specifier.
 #define MPTCPD_PRIxAID PRIx8
+
+/**
+ * @brief Mask leading MPTCP connection token bits.
+ *
+ * Logging the MPTCP connection token is a security risk.  Mask off
+ * the leading bits to make logging the @a token safer.
+ *
+ * @param[in] token MPTCP connection token.
+ *
+ * @return MPTCP connection stripped of leading bits.
+ */
+static inline mptcpd_token_t mptcpd_masked_token(mptcpd_token_t token)
+{
+        static mptcpd_token_t const mask = 0xFF;
+
+        return token & mask;
+}
 
 #ifdef __cplusplus
 }

--- a/include/mptcpd/types.h
+++ b/include/mptcpd/types.h
@@ -27,28 +27,8 @@ typedef uint32_t mptcpd_token_t;
 /// MPTCP address ID type.
 typedef uint8_t mptcpd_aid_t;
 
-/// MPTCP connection token format specifier.
-#define MPTCPD_PRIxTOKEN "#010" PRIx32
-
 /// MPTCP address ID format specifier.
 #define MPTCPD_PRIxAID PRIx8
-
-/**
- * @brief Mask leading MPTCP connection token bits.
- *
- * Logging the MPTCP connection token is a security risk.  Mask off
- * the leading bits to make logging the @a token safer.
- *
- * @param[in] token MPTCP connection token.
- *
- * @return MPTCP connection stripped of leading bits.
- */
-static inline mptcpd_token_t mptcpd_masked_token(mptcpd_token_t token)
-{
-        static mptcpd_token_t const mask = 0xFF;
-
-        return token & mask;
-}
 
 #ifdef __cplusplus
 }

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -158,9 +158,7 @@ static struct mptcpd_plugin_ops const *token_to_ops(mptcpd_token_t token)
                                  L_UINT_TO_PTR(token));
 
         if (unlikely(ops == NULL))
-                l_error("Unable to find plugin operations for "
-                        "connection token %" MPTCPD_PRIxTOKEN ".",
-                        mptcpd_masked_token(token));
+                l_error("Unable to match token to plugin.");
 
         return ops;
 }
@@ -314,9 +312,7 @@ void mptcpd_plugin_new_connection(char const *name,
         if (!l_hashmap_insert(_token_to_ops,
                               L_UINT_TO_PTR(token),
                               (void *) ops))
-                l_error("Unable to map connection token (%"
-                        MPTCPD_PRIxTOKEN ") to plugin operations.",
-                        mptcpd_masked_token(token));
+                l_error("Unable to map connection to plugin.");
 
         ops->new_connection(token, laddr, raddr, pm);
 }

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -159,8 +159,8 @@ static struct mptcpd_plugin_ops const *token_to_ops(mptcpd_token_t token)
 
         if (unlikely(ops == NULL))
                 l_error("Unable to find plugin operations for "
-                        "connection token 0x%" MPTCPD_PRIxTOKEN ".",
-                        token);
+                        "connection token %" MPTCPD_PRIxTOKEN ".",
+                        mptcpd_masked_token(token));
 
         return ops;
 }
@@ -314,9 +314,9 @@ void mptcpd_plugin_new_connection(char const *name,
         if (!l_hashmap_insert(_token_to_ops,
                               L_UINT_TO_PTR(token),
                               (void *) ops))
-                l_error("Unable to map connection token (0x%"
+                l_error("Unable to map connection token (%"
                         MPTCPD_PRIxTOKEN ") to plugin operations.",
-                        token);
+                        mptcpd_masked_token(token));
 
         ops->new_connection(token, laddr, raddr, pm);
 }

--- a/plugins/path_managers/sspi.c
+++ b/plugins/path_managers/sspi.c
@@ -566,9 +566,7 @@ static void sspi_new_connection(mptcpd_token_t token,
                 sspi_interface_info_lookup(nm, laddr);
 
         if (interface_info == NULL) {
-                l_error("Unable to track new connection (%"
-                        MPTCPD_PRIxTOKEN ")",
-                        mptcpd_masked_token(token));
+                l_error("Unable to track new connection");
 
                 return;
         }
@@ -631,9 +629,7 @@ static void sspi_connection_closed(mptcpd_token_t token,
         if (l_queue_foreach_remove(sspi_interfaces,
                                    sspi_remove_token,
                                    L_UINT_TO_PTR(token)) == 0)
-                l_error("No tracked connection with token %"
-                        MPTCPD_PRIxTOKEN,
-                        mptcpd_masked_token(token));
+                l_error("Untracked connection closed.");
 }
 
 static void sspi_new_address(mptcpd_token_t token,
@@ -690,9 +686,7 @@ static void sspi_new_subflow(mptcpd_token_t token,
                 sspi_interface_info_lookup(nm, laddr);
 
         if (info == NULL) {
-                l_error("Unable to track new subflow "
-                        "(token: %" MPTCPD_PRIxTOKEN ")",
-                        mptcpd_masked_token(token));
+                l_error("Unable to track new subflow.");
 
                 return;
         }
@@ -721,7 +715,7 @@ static void sspi_new_subflow(mptcpd_token_t token,
                             L_UINT_TO_PTR(token),
                             sspi_token_compare,
                             NULL))
-                l_error("Unable to associate new subflow token "
+                l_error("Unable to associate new subflow "
                         "with network interface %d",
                         info->index);
 }
@@ -736,13 +730,13 @@ static void sspi_subflow_closed(mptcpd_token_t token,
         (void) backup;
 
         /*
-          1. Retrieve the subflow list associated with the connection
-             token.  Return immediately if no such token exists, and
-             log an error.
+          1. Retrieve the subflow list associated with the local
+             address.  Log an error, and return immediately if no such
+             list exists.
           2. Remove the subflow information associated with the given
-             local IP address from the subflow list.  Return
-             immediately if no subflow corresponding to the local
-             address exists, and log an error.
+             local IP address from the subflow list.  Log an error,
+             and return immediately if no subflow corresponding to the
+             local address exists.
          */
 
         struct mptcpd_nm const *const nm = mptcpd_pm_get_nm(pm);
@@ -751,19 +745,15 @@ static void sspi_subflow_closed(mptcpd_token_t token,
                 sspi_interface_info_lookup(nm, laddr);
 
         if (info == NULL) {
-                l_error("Unable to remove subflow "
-                        "(token: %" MPTCPD_PRIxTOKEN ")",
-                        mptcpd_masked_token(token));
+                l_error("No tracked subflows on network interface.");
 
                 return;
         }
 
         if (!l_queue_remove(info->tokens,
                             L_UINT_TO_PTR(token)))
-                l_error("No subflow with token "
-                        "%" MPTCPD_PRIxTOKEN
-                        " exists on network interface %d.",
-                        mptcpd_masked_token(token),
+                l_error("Closed subflow was not tracked on "
+                        "network interface %d.",
                         info->index);
 }
 

--- a/plugins/path_managers/sspi.c
+++ b/plugins/path_managers/sspi.c
@@ -566,9 +566,9 @@ static void sspi_new_connection(mptcpd_token_t token,
                 sspi_interface_info_lookup(nm, laddr);
 
         if (interface_info == NULL) {
-                l_error("Unable to track new connection (0x%"
+                l_error("Unable to track new connection (%"
                         MPTCPD_PRIxTOKEN ")",
-                        token);
+                        mptcpd_masked_token(token));
 
                 return;
         }
@@ -631,9 +631,9 @@ static void sspi_connection_closed(mptcpd_token_t token,
         if (l_queue_foreach_remove(sspi_interfaces,
                                    sspi_remove_token,
                                    L_UINT_TO_PTR(token)) == 0)
-                l_error("No tracked connection with token 0x%"
+                l_error("No tracked connection with token %"
                         MPTCPD_PRIxTOKEN,
-                        token);
+                        mptcpd_masked_token(token));
 }
 
 static void sspi_new_address(mptcpd_token_t token,
@@ -691,8 +691,8 @@ static void sspi_new_subflow(mptcpd_token_t token,
 
         if (info == NULL) {
                 l_error("Unable to track new subflow "
-                        "(token: 0x%" MPTCPD_PRIxTOKEN ")",
-                        token);
+                        "(token: %" MPTCPD_PRIxTOKEN ")",
+                        mptcpd_masked_token(token));
 
                 return;
         }
@@ -752,8 +752,8 @@ static void sspi_subflow_closed(mptcpd_token_t token,
 
         if (info == NULL) {
                 l_error("Unable to remove subflow "
-                        "(token: 0x%" MPTCPD_PRIxTOKEN ")",
-                        token);
+                        "(token: %" MPTCPD_PRIxTOKEN ")",
+                        mptcpd_masked_token(token));
 
                 return;
         }
@@ -761,9 +761,9 @@ static void sspi_subflow_closed(mptcpd_token_t token,
         if (!l_queue_remove(info->tokens,
                             L_UINT_TO_PTR(token)))
                 l_error("No subflow with token "
-                        "0x%" MPTCPD_PRIxTOKEN
+                        "%" MPTCPD_PRIxTOKEN
                         " exists on network interface %d.",
-                        token,
+                        mptcpd_masked_token(token),
                         info->index);
 }
 

--- a/src/path_manager.c
+++ b/src/path_manager.c
@@ -238,7 +238,7 @@ static void handle_connection_created(struct l_genl_msg *msg,
                 return;
         }
 
-        l_debug("token: 0x%" MPTCPD_PRIxTOKEN, *token);
+        l_debug("token: %" MPTCPD_PRIxTOKEN, mptcpd_masked_token(*token));
 
         struct mptcpd_pm *const pm = user_data;
 
@@ -332,7 +332,7 @@ static void handle_connection_established(struct l_genl_msg *msg,
                 return;
         }
 
-        l_debug("token: 0x%" MPTCPD_PRIxTOKEN, *token);
+        l_debug("token: %" MPTCPD_PRIxTOKEN, mptcpd_masked_token(*token));
 
         struct mptcpd_pm *const pm = user_data;
 
@@ -386,7 +386,7 @@ static void handle_connection_closed(struct l_genl_msg *msg,
                 return;
         }
 
-        l_debug("token: 0x%" MPTCPD_PRIxTOKEN, *token);
+        l_debug("token: %" MPTCPD_PRIxTOKEN, mptcpd_masked_token(*token));
 
         struct mptcpd_pm *const pm = user_data;
 
@@ -451,7 +451,7 @@ static void handle_new_addr(struct l_genl_msg *msg, void *user_data)
                 return;
         }
 
-        l_debug("token: 0x%" MPTCPD_PRIxTOKEN, *token);
+        l_debug("token: %" MPTCPD_PRIxTOKEN, mptcpd_masked_token(*token));
 
         struct sockaddr_storage addr;
         initialize_sockaddr_storage(addr4,
@@ -513,7 +513,7 @@ static void handle_addr_removed(struct l_genl_msg *msg, void *user_data)
                 return;
         }
 
-        l_debug("token: 0x%" MPTCPD_PRIxTOKEN, *token);
+        l_debug("token: %" MPTCPD_PRIxTOKEN, mptcpd_masked_token(*token));
 
         struct mptcpd_pm *const pm = user_data;
 
@@ -625,7 +625,7 @@ static bool handle_subflow(struct l_genl_msg *msg,
 
         *token = *tok;
 
-        l_debug("token: 0x%" MPTCPD_PRIxTOKEN, *token);
+        l_debug("token: %" MPTCPD_PRIxTOKEN, mptcpd_masked_token(*token));
 
         initialize_sockaddr_storage(laddr4, laddr6, *local_port,  laddr);
         initialize_sockaddr_storage(raddr4, raddr6, *remote_port, raddr);

--- a/src/path_manager.c
+++ b/src/path_manager.c
@@ -238,8 +238,6 @@ static void handle_connection_created(struct l_genl_msg *msg,
                 return;
         }
 
-        l_debug("token: %" MPTCPD_PRIxTOKEN, mptcpd_masked_token(*token));
-
         struct mptcpd_pm *const pm = user_data;
 
         struct sockaddr_storage laddr, raddr;
@@ -332,8 +330,6 @@ static void handle_connection_established(struct l_genl_msg *msg,
                 return;
         }
 
-        l_debug("token: %" MPTCPD_PRIxTOKEN, mptcpd_masked_token(*token));
-
         struct mptcpd_pm *const pm = user_data;
 
         struct sockaddr_storage laddr, raddr;
@@ -385,8 +381,6 @@ static void handle_connection_closed(struct l_genl_msg *msg,
 
                 return;
         }
-
-        l_debug("token: %" MPTCPD_PRIxTOKEN, mptcpd_masked_token(*token));
 
         struct mptcpd_pm *const pm = user_data;
 
@@ -451,8 +445,6 @@ static void handle_new_addr(struct l_genl_msg *msg, void *user_data)
                 return;
         }
 
-        l_debug("token: %" MPTCPD_PRIxTOKEN, mptcpd_masked_token(*token));
-
         struct sockaddr_storage addr;
         initialize_sockaddr_storage(addr4,
                                     addr6,
@@ -512,8 +504,6 @@ static void handle_addr_removed(struct l_genl_msg *msg, void *user_data)
 
                 return;
         }
-
-        l_debug("token: %" MPTCPD_PRIxTOKEN, mptcpd_masked_token(*token));
 
         struct mptcpd_pm *const pm = user_data;
 
@@ -624,8 +614,6 @@ static bool handle_subflow(struct l_genl_msg *msg,
         }
 
         *token = *tok;
-
-        l_debug("token: %" MPTCPD_PRIxTOKEN, mptcpd_masked_token(*token));
 
         initialize_sockaddr_storage(laddr4, laddr6, *local_port,  laddr);
         initialize_sockaddr_storage(raddr4, raddr6, *remote_port, raddr);


### PR DESCRIPTION
Logging the MPTCP connection token is security risk.  Remove all such log messages.

Fixes #25.