### PR TITLE
mptcpd 0.3: Beta release

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,38 @@
+18 December 2019 - mptcpd 0.3
+
+- This is the Multipath TCP Daemon beta release.
+
+- All known memory leaks have been fixed.
+
+- A potential security hole related to logging of MPTCP connection
+  tokens was closed.  Logging of MPTCP connection tokens no longer
+  occurs.
+
+- Support for compiler-based address, leak, and undefined behavior
+  sanitizers is now available, and may be enabled through
+  corresponding `configure' script options.  Run `./configure --help'
+  for the full list of options.
+
+- Diagnostic messages will be issued if the Linux kernel is not
+  properly configured to support a user space MPTCP path manager like
+  mptcpd.
+
+- Documentation on how to contribute to mptcpd is available in the
+  `CONTRIBUTING.md' file.
+
+- A pkg-config `mptcpd.pc' file is now generated and installed to
+  allow plugin developers to more easily obtain the necessary mptcpd
+  build related information, such as compiler and linker command line
+  flags.
+
+- The mptcpd plugin API dropped the mptcpd_addr type in favor of the
+  standard sockaddr family of structures.
+
+- Debugger-friendly optimization is now supported.
+
+- ELL 0.21 or better is now required due to changes in the ELL generic
+  netlink API.
+
 11 June 2019 - mptcpd 0.2a
 
 - This Multipath TCP Daemon alpha release replaces support for the

--- a/NEWS
+++ b/NEWS
@@ -30,7 +30,7 @@
 
 - Debugger-friendly optimization is now supported.
 
-- ELL 0.21 or better is now required due to changes in the ELL generic
+- ELL 0.27 or better is now required due to changes in the ELL generic
   netlink API.
 
 11 June 2019 - mptcpd 0.2a

--- a/README-alpha
+++ b/README-alpha
@@ -1,3 +1,0 @@
-This is an experimental (alpha) release.  Noticeable differences
-between this release and the next one may occur.  Do not rely on
-behavior specific to this release.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ archive or from a cloned Git `mptcpd` repository, for example.
 
 * Basic `mptcpd` Build Dependencies
   * C compiler (C99 compliant)
-  * [Embedded Linux Library](https://git.kernel.org/pub/scm/libs/ell/ell.git) >= v0.21
+  * [Embedded Linux Library](https://git.kernel.org/pub/scm/libs/ell/ell.git) >= v0.27
   * Argp library (either the GNU libc
     [built-in](https://www.gnu.org/software/libc/manual/html_node/Argp.html)
     or [standalone](http://www.lysator.liu.se/~nisse/misc/))

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@
 
 AC_PREREQ([2.69])
 AC_INIT([mptcpd],
-        [0.2a],
+        [0.3],
         [mptcp@lists.01.org],
         [],
         [https://01.org/multipath-tcp-linux])

--- a/configure.ac
+++ b/configure.ac
@@ -31,7 +31,7 @@ dnl Support "--enable-debug=..." configure script command line option.
 AX_IS_RELEASE([git-directory])
 AX_CHECK_ENABLE_DEBUG([yes])
 
-AM_INIT_AUTOMAKE([1.15 -Wall -Werror -Wno-portability silent-rules std-options check-news readme-alpha])
+AM_INIT_AUTOMAKE([1.15 -Wall -Werror -Wno-portability silent-rules std-options check-news])
 AM_SILENT_RULES([yes])
 LT_INIT([disable-static])
 

--- a/configure.ac
+++ b/configure.ac
@@ -171,7 +171,7 @@ AM_CONDITIONAL([BUILDING_DLL], [test "x$enable_shared" = xyes])
 # ---------------------------------------------------------------
 # Checks for libraries.
 # ---------------------------------------------------------------
-PKG_CHECK_MODULES([ELL], [ell >= 0.21])
+PKG_CHECK_MODULES([ELL], [ell >= 0.27])
 
 # ---------------------------------------------------------------
 # Checks for header files.

--- a/lib/mptcpd.pc.in
+++ b/lib/mptcpd.pc.in
@@ -17,6 +17,6 @@ Name: @PACKAGE_NAME@
 Description: The Multipath TCP Daemon library
 URL: @PACKAGE_URL@
 Version: @VERSION@
-Requires.private: ell >= 0.21
+Requires.private: ell >= 0.27
 Cflags: -I${includedir}
 Libs: -L${libdir} -lmptcpd

--- a/lib/mptcpd.pc.in
+++ b/lib/mptcpd.pc.in
@@ -10,7 +10,7 @@ includedir=@includedir@
 # built.  It may differ from the actual site-specific plugin directory
 # if the default directory was overridden in the mptcpd configuration
 # file or on the command line.
-pkglibdir=@libdir@/@PACKAGE@
+plugindir=@libdir@/@PACKAGE@
 
 # Package keywords.
 Name: @PACKAGE_NAME@


### PR DESCRIPTION
This is the Multipath TCP Daemon beta release.

- All known memory leaks have been fixed.

- A potential security hole related to logging of MPTCP connection
  tokens was closed.  Logging of MPTCP connection tokens no longer
  occurs.

- Support for compiler-based address, leak, and undefined behavior sanitizers is now available, and may be enabled through corresponding `configure` script options.  Run `./configure --help`  for the full list of options.

- Diagnostic messages will be issued if the Linux kernel is not properly configured to support a user space MPTCP path manager like mptcpd.

- Documentation on how to contribute to mptcpd is available in the [`CONTRIBUTING.md`](https://github.com/intel/mptcpd/blob/master/CONTRIBUTING.md) file.

- A `pkg-config` [`mptcpd.pc`](https://github.com/intel/mptcpd/blob/master/lib/mptcpd.pc.in) file is now generated and installed to allow plugin developers to more easily obtain the necessary mptcpd build related information, such as compiler and linker command line flags.

- The mptcpd plugin API dropped the `mptcpd_addr` type in favor of the standard `sockaddr` family of structures.

- Debugger-friendly optimization has been improved.

- ELL 0.21 or better is now required due to changes in the ELL generic netlink API.