### PR TITLE
Automatically update ELL version in `mptcpd.pc'.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -171,7 +171,9 @@ AM_CONDITIONAL([BUILDING_DLL], [test "x$enable_shared" = xyes])
 # ---------------------------------------------------------------
 # Checks for libraries.
 # ---------------------------------------------------------------
-PKG_CHECK_MODULES([ELL], [ell >= 0.27])
+ELL_VERSION=0.27  dnl Minimum required version of ELL.
+PKG_CHECK_MODULES([ELL], [ell >= $ELL_VERSION])
+AC_SUBST([ELL_VERSION])
 
 # ---------------------------------------------------------------
 # Checks for header files.

--- a/lib/mptcpd.pc.in
+++ b/lib/mptcpd.pc.in
@@ -17,6 +17,6 @@ Name: @PACKAGE_NAME@
 Description: The Multipath TCP Daemon library
 URL: @PACKAGE_URL@
 Version: @VERSION@
-Requires.private: ell >= 0.27
+Requires.private: ell >= @ELL_VERSION@
 Cflags: -I${includedir}
 Libs: -L${libdir} -lmptcpd


### PR DESCRIPTION
Automatically update the minimum required version of ELL in the
`mptcpd.pc' pkg-config file to match the version in the configure
script to avoid potential mismatches.