### PR TITLE
tests: Clean up temporary plugin test directory.

### DIFF
--- a/tests/test-plugin.c
+++ b/tests/test-plugin.c
@@ -114,6 +114,9 @@ static void test_no_plugins(void const *test_data)
         assert(dir != NULL);
 
         bool const loaded = mptcpd_plugin_load(dir, NULL);
+
+        (void) rmdir(dir);
+
         assert(!loaded);
 }
 


### PR DESCRIPTION
The mptcpd plugin unit test created a temporary test directory but did
not remove it.  Remove that directory as soon as it is no longer
needed.