### PR TITLE
lib: Verify plugin op is non-NULL before calling.

### DIFF
--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -4,7 +4,7 @@
  *
  * @brief Common path manager plugin functions.
  *
- * Copyright (c) 2018, 2019, Intel Corporation
+ * Copyright (c) 2018-2020, Intel Corporation
  */
 
 #include <sys/types.h>
@@ -270,6 +270,20 @@ bool mptcpd_plugin_register_ops(char const *name,
         if (name == NULL || ops == NULL)
                 return false;
 
+        /**
+         * @todo Should we return @c false if all of the callbacks in
+         *       @a ops are @c NULL?
+         */
+        if (ops->new_connection            == NULL
+            && ops->connection_established == NULL
+            && ops->connection_closed      == NULL
+            && ops->new_address            == NULL
+            && ops->address_removed        == NULL
+            && ops->new_subflow            == NULL
+            && ops->subflow_closed         == NULL
+            && ops->subflow_priority       == NULL)
+                l_warn("No plugin operations were set.");
+
         bool const first_registration = l_hashmap_isempty(_pm_plugins);
 
         bool const registered =
@@ -314,7 +328,8 @@ void mptcpd_plugin_new_connection(char const *name,
                               (void *) ops))
                 l_error("Unable to map connection to plugin.");
 
-        ops->new_connection(token, laddr, raddr, pm);
+        if (ops->new_connection)
+                ops->new_connection(token, laddr, raddr, pm);
 }
 
 void mptcpd_plugin_connection_established(mptcpd_token_t token,
@@ -324,7 +339,7 @@ void mptcpd_plugin_connection_established(mptcpd_token_t token,
 {
         struct mptcpd_plugin_ops const *const ops = token_to_ops(token);
 
-        if (ops)
+        if (ops && ops->connection_established)
                 ops->connection_established(token, laddr, raddr, pm);
 }
 
@@ -333,7 +348,7 @@ void mptcpd_plugin_connection_closed(mptcpd_token_t token,
 {
         struct mptcpd_plugin_ops const *const ops = token_to_ops(token);
 
-        if (ops)
+        if (ops && ops->connection_closed)
                 ops->connection_closed(token, pm);
 }
 
@@ -344,7 +359,7 @@ void mptcpd_plugin_new_address(mptcpd_token_t token,
 {
         struct mptcpd_plugin_ops const *const ops = token_to_ops(token);
 
-        if (ops)
+        if (ops && ops->new_address)
                 ops->new_address(token, id, addr, pm);
 }
 
@@ -354,7 +369,7 @@ void mptcpd_plugin_address_removed(mptcpd_token_t token,
 {
         struct mptcpd_plugin_ops const *const ops = token_to_ops(token);
 
-        if (ops)
+        if (ops && ops->address_removed)
                 ops->address_removed(token, id, pm);
 }
 
@@ -366,7 +381,7 @@ void mptcpd_plugin_new_subflow(mptcpd_token_t token,
 {
         struct mptcpd_plugin_ops const *const ops = token_to_ops(token);
 
-        if (ops)
+        if (ops && ops->new_subflow)
                 ops->new_subflow(token, laddr, raddr, backup, pm);
 }
 
@@ -378,7 +393,7 @@ void mptcpd_plugin_subflow_closed(mptcpd_token_t token,
 {
         struct mptcpd_plugin_ops const *const ops = token_to_ops(token);
 
-        if (ops)
+        if (ops && ops->subflow_closed)
                 ops->subflow_closed(token, laddr, raddr, backup, pm);
 
 }
@@ -391,7 +406,7 @@ void mptcpd_plugin_subflow_priority(mptcpd_token_t token,
 {
         struct mptcpd_plugin_ops const *const ops = token_to_ops(token);
 
-        if (ops)
+        if (ops && ops->subflow_priority)
                 ops->subflow_priority(token, laddr, raddr, backup, pm);
 
 }

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -328,7 +328,7 @@ void mptcpd_plugin_new_connection(char const *name,
                               (void *) ops))
                 l_error("Unable to map connection to plugin.");
 
-        if (ops->new_connection)
+        if (ops && ops->new_connection)
                 ops->new_connection(token, laddr, raddr, pm);
 }
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,6 +1,6 @@
 ## SPDX-License-Identifier: BSD-3-Clause
 ##
-## Copyright (c) 2017-2019, Intel Corporation
+## Copyright (c) 2017-2020, Intel Corporation
 
 ## @todo Do not add the EXECUTABLE_* flags to test libraries (if any).
 AM_CPPFLAGS = -I$(top_srcdir)/include
@@ -138,13 +138,14 @@ xfail_test_scripts =		\
 dist_check_SCRIPTS = test-start-stop $(xfail_test_scripts)
 
 test_plugin_SOURCES = test-plugin.c
-test_plugin_CPPFLAGS =					\
-	-I$(top_srcdir)/include				\
-	-D_POSIX_C_SOURCE=200809L			\
-	-DTEST_PLUGIN_DIR_A=\"$(TEST_PLUGIN_DIR_A)\"	\
-	-DTEST_PLUGIN_DIR_B=\"$(TEST_PLUGIN_DIR_B)\"	\
-	-DTEST_PLUGIN_ONE=\"$(TEST_PLUGIN_ONE)\"	\
-	-DTEST_PLUGIN_TWO=\"$(TEST_PLUGIN_TWO)\"	\
+test_plugin_CPPFLAGS =						\
+	-I$(top_srcdir)/include					\
+	-D_POSIX_C_SOURCE=200809L				\
+	-DTEST_PLUGIN_DIR_A=\"$(TEST_PLUGIN_DIR_A)\"		\
+	-DTEST_PLUGIN_DIR_B=\"$(TEST_PLUGIN_DIR_B)\"		\
+	-DTEST_PLUGIN_DIR_NOOP=\"$(TEST_PLUGIN_DIR_NOOP)\"	\
+	-DTEST_PLUGIN_ONE=\"$(TEST_PLUGIN_ONE)\"		\
+	-DTEST_PLUGIN_TWO=\"$(TEST_PLUGIN_TWO)\"		\
 	-DTEST_PLUGIN_FOUR=\"$(TEST_PLUGIN_FOUR)\"
 test_plugin_LDADD =				\
 	$(top_builddir)/lib/libmptcpd.la	\


### PR DESCRIPTION
While not initially intended, the mptcpd plugin framework allows an instance of `mptcpd_plugin_ops` with `NULL` callback fields to be registered.  However, the plugin framework did not check if the callback was `NULL` prior to calling.  Add the appropriate `NULL` check prior to invoking the plugin callback to prevent a seg fault from occurring.  This also allows the user to avoid having to implement stubs for unused plugin operations.  Fixes #65.
