### PR TITLE
Add missing support for REMOVE_ADDR.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+- Plugins may now inform peers that an address is no longer being
+  advertised through the new mptcpd_pm_remove_addr() function.
+
 - Network monitoring related events are now propagated to plugins.
   Events are triggered upon the addition, update, and removal of a
   network interface (link), as well as the addition and removal of a

--- a/include/mptcpd/path_manager.h
+++ b/include/mptcpd/path_manager.h
@@ -4,7 +4,7 @@
  *
  * @brief mptcpd generic netlink commands.
  *
- * Copyright (c) 2017-2019, Intel Corporation
+ * Copyright (c) 2017-2020, Intel Corporation
  */
 
 #ifndef MPTCPD_LIB_PATH_MANAGER_H
@@ -36,11 +36,11 @@ struct mptcpd_pm;
 MPTCPD_API bool mptcpd_pm_ready(struct mptcpd_pm const *pm);
 
 /**
- * @brief Send @c MPTCP_GENL_CMD_SEND_ADDR genl command to kernel.
+ * @brief Send @c MPTCP_CMD_ANNOUNCE genl command to kernel.
  *
  * @param[in] pm         The mptcpd path manager object.
  * @param[in] token      MPTCP connection token.
- * @param[in] address_id MPTCP local address ID
+ * @param[in] address_id MPTCP local address ID.
  * @param[in] addr       MPTCP local IP address and port to be
  *                       advertised through the MPTCP protocol
  *                       @c ADD_ADDR option.  The port is optional,
@@ -52,6 +52,22 @@ MPTCPD_API bool mptcpd_pm_send_addr(struct mptcpd_pm *pm,
                                     mptcpd_token_t token,
                                     mptcpd_aid_t address_id,
                                     struct sockaddr const *addr);
+
+/**
+ * @brief Send @c MPTCP_CMD_REMOVE genl command to kernel.
+ *
+ * @param[in] pm         The mptcpd path manager object.
+ * @param[in] token      MPTCP connection token.
+ * @param[in] address_id MPTCP local address ID to be sent in the
+ *                       MPTCP protocol @c REMOVE_ADDR option
+ *                       corresponding to the local address that will
+ *                       no longer be available.
+ *
+ * @return @c true if operation was successful. @c false otherwise.
+ */
+MPTCPD_API bool mptcpd_pm_remove_addr(struct mptcpd_pm *pm,
+                                      mptcpd_token_t token,
+                                      mptcpd_aid_t address_id);
 
 /**
  * @brief Send @c MPTCP_GENL_CMD_ADD_SUBFLOW genl command to kernel.

--- a/include/mptcpd/path_manager.h
+++ b/include/mptcpd/path_manager.h
@@ -70,7 +70,7 @@ MPTCPD_API bool mptcpd_pm_remove_addr(struct mptcpd_pm *pm,
                                       mptcpd_aid_t address_id);
 
 /**
- * @brief Send @c MPTCP_GENL_CMD_ADD_SUBFLOW genl command to kernel.
+ * @brief Send @c MPTCP_CMD_SUB_CREATE genl command to kernel.
  *
  * @param[in] pm                The mptcpd path manager object.
  * @param[in] token             MPTCP connection token.
@@ -97,7 +97,7 @@ mptcpd_pm_add_subflow(struct mptcpd_pm *pm,
                       bool backup);
 
 /**
- * @brief Send @c MPTCP_GENL_CMD_SET_BACKUP genl command to kernel.
+ * @brief Send @c MPTCP_CMD_SUB_PRIORITY genl command to kernel.
  *
  * @param[in] pm                The mptcpd path manager object.
  * @param[in] token             MPTCP connection token.
@@ -118,7 +118,7 @@ MPTCPD_API bool mptcpd_pm_set_backup(
         bool backup);
 
 /**
- * @brief Send @c MPTCP_GENL_CMD_REMOVE_SUBFLOW genl command to kernel.
+ * @brief Send @c MPTCP_CMD_SUB_DESTROY genl command to kernel.
  *
  * @param[in] pm                The mptcpd path manager object.
  * @param[in] token             MPTCP connection token.

--- a/include/mptcpd/plugin.h
+++ b/include/mptcpd/plugin.h
@@ -104,9 +104,6 @@ struct mptcpd_plugin_ops
          *
          * Called when an address has been advertised by a peer
          * through an @c ADD_ADDR MPTCP option.
-         *
-         * @todo Why don't we have an @c address_removed() operation
-         *       for the @c REMOVE_ADDR case?
          */
         void (*new_address)(mptcpd_token_t token,
                             mptcpd_aid_t id,

--- a/tests/test-commands.c
+++ b/tests/test-commands.c
@@ -4,7 +4,7 @@
  *
  * @brief mptcpd commands API test.
  *
- * Copyright (c) 2019, Intel Corporation
+ * Copyright (c) 2019-2020, Intel Corporation
  */
 
 #undef NDEBUG
@@ -66,6 +66,18 @@ void test_send_addr(void const *test_data)
                                    test_token_1,
                                    test_laddr_id_1,
                                    laddr1));
+}
+
+void test_remove_addr(void const *test_data)
+{
+        struct mptcpd_pm *const pm = (struct mptcpd_pm *) test_data;
+
+        if (!is_pm_ready(pm, __func__))
+                return;
+
+        assert(mptcpd_pm_remove_addr(pm,
+                                     test_token_1,
+                                     test_laddr_id_1));
 }
 
 void test_add_subflow(void const *test_data)
@@ -182,6 +194,7 @@ int main(void)
         l_test_init(&argc, &args);
 
         l_test_add("send_addr",      test_send_addr,      pm);
+        l_test_add("remove_addr",    test_remove_addr,    pm);
         l_test_add("add_subflow",    test_add_subflow,    pm);
         l_test_add("set_backup",     test_set_backup,     pm);
         l_test_add("remove_subflow", test_remove_subflow, pm);


### PR DESCRIPTION
Support for sending the `REMOVE_ADDR` MPTCP option through the `MPTCP_CMD_REMOVE` generic netlink command was missing.  Add a new `mptcp_pm_remove_addr()` function that provides this functionality to allow mptcpd path manager plugins to stop advertising specific addresses.
