### PR TITLE
Correct C++ debug optimization flag order.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -162,6 +162,13 @@ AS_IF([test "x$ax_enable_debug" != "xyes"],
        dnl Minimal optimization for the debug case.  We need this for
        dnl _FORTIFY_SOURCE support, too.
        MPTCPD_ADD_COMPILE_FLAG([-Og])
+
+       dnl Enable debug optimization for C++ build test, too.
+       AS_IF([test -n "$CXX"],
+             [AC_LANG_PUSH([C++])
+              AX_APPEND_COMPILE_FLAGS([-Og])
+              AC_LANG_POP([C++])
+             ])
       ])
 
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -95,7 +95,6 @@ test_cxx_build_CPPFLAGS =					\
 	$(AM_CPPFLAGS)						\
 	-DTEST_PLUGIN_DIR=\"$(TEST_PLUGIN_DIR_SECURITY)\"	\
 	-DTEST_PLUGIN_FOUR=\"@TEST_PLUGIN_FOUR@\"
-test_cxx_build_CXXFLAGS = $(AM_CXXFLAGS) -Og
 test_cxx_build_LDADD =				\
 	$(top_builddir)/lib/libmptcpd.la	\
 	$(builddir)/lib/libmptcpd_test.la	\


### PR DESCRIPTION
To properly support gcc's _FORTIFY_SOURCE feature some optimization
level above zero (i.e., "-O0") is required.  Mptcpd explicitly adds
the "-Og" flag when debugging is enabled, but that flag was being
overridden for the mptcpd C++ build test, `test-cxx-build', due to the
way it was appended to the C++ compiler flags variable, CXXFLAGS.
CXXFLAGS ended up containing "-Og -g -O0".  The trailing optimization
flag "-O0" superceded the earlier "-Og" flag, which ultimately caused
optimization to be disabled entirely.  That triggered a preprocessor
warning on some platforms:

  /usr/include/features.h:397:4: warning: #warning _FORTIFY_SOURCE
    requires compiling with optimization (-O) [-Wcpp]

Append the "-Og" flag to CXXFLAGS in the `configure' script rather
than the Makefile to work around the optimization flag ordering
issue.  CXXFLAGS now contains "-g -O0 -Og", which causes "-Og" to
supercede "-O0" on the compiler command line.  This enables enough
optimization to support both debugging and _FORTIFY_SOURCE.

This change also allows the default optimization level "-O2" to be
used for the test-cxx-build program when debugging is disabled.

Fixes #80.