### PR TITLE
tests: Workaround C++ error in <ell/util.h>.

### DIFF
--- a/tests/test-cxx-build.cpp
+++ b/tests/test-cxx-build.cpp
@@ -14,7 +14,6 @@
 
 #include <ell/main.h>
 #include <ell/idle.h>
-#include <ell/util.h>  // Needed by <ell/log.h>
 #include <ell/log.h>
 
 #include <mptcpd/path_manager.h>   // Include to test build under C++.


### PR DESCRIPTION
The mptcpd test-cxx-build unit test fails to compile with recent
versions of ELL (e.g., 0.33) due to an assignment of a void* to a
uint8_t* without a cast in the inline l_secure_memcmp() function in
<ell/util.h>.  Drop the <ell/util.h> include from tests-cxx-build.cpp
to address the C++ build problem since it is no longer needed.