### PR TITLE
Update plugin framework to not depend on ELL

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,14 @@
+- Mptcpd now supports versions of the Embedded Linux Library (ELL)
+  greater than 0.33.
+
+- Plugins should use the new MPTCPD_PLUGIN_DEFINE() preprocessor macro
+  instead of L_PLUGIN_DEFINE().
+
+- A pointer to the mptcpd path manager object, i.e. struct mptcpd *pm,
+  is now passed to the plugin init and exit functions.  This allows
+  plugins to potentially perform mptcpd path manager related
+  operations during initialization and finalization.
+
 - Support for the MPTCP netlink path manager in the upstream Linux
   kernel is now available.  A new set of path management command
   functions corresponding to those available in the kernel netlink

--- a/configure.ac
+++ b/configure.ac
@@ -206,6 +206,12 @@ AC_SEARCH_LIBS(
     [],
     [AC_MSG_ERROR([library with argp_parse() could not be found])])
 
+AC_SEARCH_LIBS(
+    [dlopen],
+    [dl],
+    [],
+    [AC_MSG_ERROR([library with dlopen() could not be found])])
+
 # ---------------------------------------------------------------
 # Enable additional C compiler warnings.  We do this after all
 # Autoconf tests have been run since not all autoconf macros are

--- a/configure.ac
+++ b/configure.ac
@@ -111,9 +111,9 @@ AC_SUBST([mptcpd_logger],[$enable_logging])
 # Allow the user to set the default path manager plugin at 'configure-time'.
 AC_ARG_WITH([path-manager],
      [AS_HELP_STRING([--with-path-manager[=PLUGIN]],
-                     [Set default path manager plugin to PLUGIN (sspi, reject_join) @<:@default=sspi@:>@])],
+                     [Set default path manager plugin to PLUGIN (addr_adv, sspi) @<:@default=addr_adv@:>@])],
      [AS_CASE([$withval],
-              [sspi | reject_join],
+              [addr_adv | sspi],
               [with_path_manager=$withval],
               [AC_MSG_ERROR([invalid path manager plugin: $withval])])],
      [with_path_manager=sspi])

--- a/configure.ac
+++ b/configure.ac
@@ -178,10 +178,9 @@ AM_CONDITIONAL([BUILDING_DLL], [test "x$enable_shared" = xyes])
 # ---------------------------------------------------------------
 # Checks for libraries.
 # ---------------------------------------------------------------
-ELL_MIN_VERSION=0.27  dnl Minimum required version of ELL.
-ELL_MAX_VERSION=0.33  dnl Maximum required version of ELL.
+ELL_VERSION=0.27  dnl Minimum required version of ELL.
 PKG_CHECK_MODULES([ELL],
-                  [ell >= $ELL_MIN_VERSION ell <= $ELL_MAX_VERSION])
+                  [ell >= $ELL_VERSION])
 AC_SUBST([ELL_VERSION])
 
 # ---------------------------------------------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -116,7 +116,7 @@ AC_ARG_WITH([path-manager],
               [addr_adv | sspi],
               [with_path_manager=$withval],
               [AC_MSG_ERROR([invalid path manager plugin: $withval])])],
-     [with_path_manager=sspi])
+     [with_path_manager=addr_adv])
 
 AC_SUBST([mptcpd_default_pm],[$with_path_manager])
 

--- a/include/mptcpd/plugin.h
+++ b/include/mptcpd/plugin.h
@@ -19,17 +19,98 @@
 extern "C" {
 #endif
 
-/**
- * @brief Mptcpd plugin @a "symbol" argument for @c L_PLUGIN_DEFINE.
- *
- * All mptcpd plugins are expected to use this value as the @a symbol
- * argument in their @c L_PLUGIN_DEFINE() macro call.
- */
-#define MPTCPD_PLUGIN_DESC mptcpd_plugin_desc
-
 struct sockaddr;
 struct mptcpd_pm;
 struct mptcpd_interface;
+
+/**
+ * @brief Symbol name of mptcpd plugin characterstics.
+ *
+ * @note This is a private preprocessor constant that is not part of
+ *       the mptcpd plugin API.
+ */
+#define MPTCPD_PLUGIN_SYM _mptcpd_plugin
+
+/**
+ * @brief Define mptcpd plugin characterstics.
+ *
+ * Mptcpd plugins should use this macro to define and export
+ * characterstics (descriptor) required by mptcpd.
+ *
+ * @param[in] name        Plugin name (unquoted)
+ * @param[in] description Plugin description
+ * @param[in] priority    Plugin priority, where the higher values are
+ *                        lower in priority, and lower values are
+ *                        higher in priority, similar to how process
+ *                        scheduling priorities are defined.  Mptcpd
+ *                        defines convenience plugin priorities
+ *                        @c MPTCP_PLUGIN_PRIORITY_LOW,
+ *                        @c MPTCP_PLUGIN_PRIORITY_DEFAULT, and
+ *                        @c  MPTCP_PLUGIN_PRIORITY_HIGH.
+ * @param[in] init        Function called when mptcpd initializes the
+ *                        plugin.
+ * @param[in] exit        Function called when mptcpd finalizes the
+ *                        plugin.
+ */
+#define MPTCPD_PLUGIN_DEFINE(name, description, priority, init, exit)   \
+        extern struct mptcpd_plugin_desc const MPTCPD_PLUGIN_SYM        \
+                __attribute__((visibility("default")));                 \
+        struct mptcpd_plugin_desc const MPTCPD_PLUGIN_SYM = {           \
+                #name,                                                  \
+                description,                                            \
+                0, /* version */                                        \
+                priority,                                               \
+                init,                                                   \
+                exit                                                    \
+        };
+
+/// Lowest priority value, i.e. highest priority
+#define MPTCPD_PLUGIN_PRIORITY_LOW     -20
+
+/// Default priority
+#define MPTCPD_PLUGIN_PRIORITY_DEFAULT   0
+
+/// Higher priority value, i.e. lowest priority
+#define MPTCPD_PLUGIN_PRIORITY_HIGH     19
+
+/**
+ * @struct mptcpd_plugin_desc
+ *
+ * @brief Plugin-specific characteristics / descriptor.
+ */
+struct mptcpd_plugin_desc
+{
+        /**
+         * @privatesection
+         */
+        /// Plugin name.
+        char const *const name;
+
+        /// Plugin description.
+        char const *const description;
+
+        /// mptcpd version against which the plugin was compiled.
+        char const *const version;
+
+        /**
+         * @brief Plugin priority.
+         *
+         * Plugin priority, where the higher values are lower in
+         * priority, and lower values are higher in priority, similar
+         * to how process scheduling priorities are defined.
+         *
+         * @see @c MPTCP_PLUGIN_PRIORITY_LOW
+         * @see @c MPTCP_PLUGIN_PRIORITY_DEFAULT
+         * @see @c MPTCP_PLUGIN_PRIORITY_HIGH
+         */
+        int const priority;
+
+        /// Plugin initialization function.
+        int (*init)(struct mptcpd_pm *);
+
+        /// Plugin finalization function.
+        void (*exit)(struct mptcpd_pm *);
+};
 
 /**
  * @struct mptcpd_plugin_ops plugin.h <mptcpd/plugin.h>

--- a/include/mptcpd/plugin.h
+++ b/include/mptcpd/plugin.h
@@ -64,14 +64,14 @@ struct mptcpd_interface;
                 exit                                                    \
         };
 
-/// Lowest priority value, i.e. highest priority
-#define MPTCPD_PLUGIN_PRIORITY_LOW     -20
+/// Low plugin priority.
+#define MPTCPD_PLUGIN_PRIORITY_LOW     19
 
-/// Default priority
-#define MPTCPD_PLUGIN_PRIORITY_DEFAULT   0
+/// Default plugin priority.
+#define MPTCPD_PLUGIN_PRIORITY_DEFAULT 0
 
-/// Higher priority value, i.e. lowest priority
-#define MPTCPD_PLUGIN_PRIORITY_HIGH     19
+/// High plugin priority.
+#define MPTCPD_PLUGIN_PRIORITY_HIGH    -20
 
 /**
  * @struct mptcpd_plugin_desc

--- a/include/mptcpd/plugin.h
+++ b/include/mptcpd/plugin.h
@@ -11,6 +11,7 @@
 #define MPTCPD_PLUGIN_H
 
 #include <stdbool.h>
+#include <limits.h>
 
 #include <mptcpd/export.h>
 #include <mptcpd/types.h>
@@ -64,14 +65,14 @@ struct mptcpd_interface;
                 exit                                                    \
         };
 
-/// Lowest priority value, i.e. highest priority
-#define MPTCPD_PLUGIN_PRIORITY_LOW     -20
+/// Lowest priority value.
+#define MPTCPD_PLUGIN_PRIORITY_LOW     INT_MIN
 
-/// Default priority
-#define MPTCPD_PLUGIN_PRIORITY_DEFAULT   0
+/// Default priority.
+#define MPTCPD_PLUGIN_PRIORITY_DEFAULT 0
 
-/// Higher priority value, i.e. lowest priority
-#define MPTCPD_PLUGIN_PRIORITY_HIGH     19
+/// Higher priority value.
+#define MPTCPD_PLUGIN_PRIORITY_HIGH    INT_MAX
 
 /**
  * @struct mptcpd_plugin_desc

--- a/include/mptcpd/plugin.h
+++ b/include/mptcpd/plugin.h
@@ -11,7 +11,6 @@
 #define MPTCPD_PLUGIN_H
 
 #include <stdbool.h>
-#include <limits.h>
 
 #include <mptcpd/export.h>
 #include <mptcpd/types.h>
@@ -65,14 +64,14 @@ struct mptcpd_interface;
                 exit                                                    \
         };
 
-/// Lowest priority value.
-#define MPTCPD_PLUGIN_PRIORITY_LOW     INT_MIN
+/// Lowest priority value, i.e. highest priority
+#define MPTCPD_PLUGIN_PRIORITY_LOW     -20
 
-/// Default priority.
-#define MPTCPD_PLUGIN_PRIORITY_DEFAULT 0
+/// Default priority
+#define MPTCPD_PLUGIN_PRIORITY_DEFAULT   0
 
-/// Higher priority value.
-#define MPTCPD_PLUGIN_PRIORITY_HIGH    INT_MAX
+/// Higher priority value, i.e. lowest priority
+#define MPTCPD_PLUGIN_PRIORITY_HIGH     19
 
 /**
  * @struct mptcpd_plugin_desc

--- a/include/mptcpd/plugin_private.h
+++ b/include/mptcpd/plugin_private.h
@@ -33,16 +33,21 @@ struct mptcpd_interface;
  * @param[in] dir          Directory from which plugins will be loaded.
  * @param[in] default_name Name of plugin to be considered the
  *                         default.
+ * @param[in] pm           Opaque pointer to mptcpd path manager
+ *                         object.
  *
  * @return @c true on successful load, @c false otherwise.
  */
 MPTCPD_API bool mptcpd_plugin_load(char const *dir,
-                                   char const *default_name);
+                                   char const *default_name,
+                                   struct mptcpd_pm *pm);
 
 /**
  * @brief Unload mptcpd plugins.
+ *
+ * @param[in] pm Opaque pointer to mptcpd path manager object.
  */
-MPTCPD_API void mptcpd_plugin_unload(void);
+MPTCPD_API void mptcpd_plugin_unload(struct mptcpd_pm *pm);
 
 /**
  * @brief Notify plugin of new MPTCP connection pending completion.

--- a/lib/mptcpd.pc.in
+++ b/lib/mptcpd.pc.in
@@ -20,3 +20,4 @@ Version: @VERSION@
 Requires.private: ell >= @ELL_VERSION@
 Cflags: -I${includedir}
 Libs: -L${libdir} -lmptcpd
+Libs.private: @LIBS@

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -185,9 +185,9 @@ static struct l_queue *_plugin_infos;
  * @param[in] b         Existing plugin information.
  * @param[in] user_data User data (unused).
  *
- * @return Value greater than 0 if the new plugin should be inserted
- *         after the existing plugin in the list, and a negative value
- *         otherwise.
+ * @return Value greater than or equal to 0 if the new plugin should
+ *         be inserted after the existing plugin in the list, and a
+ *         negative value otherwise.
  */
 static int compare_plugin_priority(void const *a,
                                    void const *b,
@@ -201,9 +201,11 @@ static int compare_plugin_priority(void const *a,
         /*
           Cause "new" plugin to be inserted into the plugin list
           before the "existing" plugin it its priority is higher
-          (lower value) than the existing plugin priority.
+          than the existing plugin priority.
         */
-        return new->desc->priority - existing->desc->priority;
+        return new->desc->priority > existing->desc->priority
+                ? -1   // Insert "new" before "existing".
+                :  1;  // Append to end of queue.
 }
 
 static void report_error(int error, char const *msg)

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -433,6 +433,7 @@ bool mptcpd_plugin_load(char const *dir,
                     || l_hashmap_isempty(_pm_plugins)) {
                         l_hashmap_destroy(_pm_plugins, NULL);
                         _pm_plugins = NULL;
+                        unload_plugins(pm);
 
                         return false;  // Plugin load and registration
                                        // failed.

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -56,11 +56,6 @@
  * instance.
  *
  * @todo Consider merging this map the @c plugin_infos queue.
- *
- * @note This is a static variable since ELL's plugin framework
- *       doesn't provide a way to pass user data to loaded plugins.
- *       Access to this variable may need to be synchronized if mptcpd
- *       ever supports multiple threads.
  */
 static struct l_hashmap *_pm_plugins;
 
@@ -70,11 +65,6 @@ static struct l_hashmap *_pm_plugins;
  * @todo Determine if use of a hashmap scales well, in terms
  *       of both performance and resource usage, in the
  *       presence of a large number of MPTCP connections.
- *
- * @note This is a static variable since ELL's plugin framework
- *       doesn't provide a way to pass user data to loaded plugins.
- *       Access to this variable may need to be synchronized if mptcpd
- *       ever supports multiple threads.
  */
 static struct l_hashmap *_token_to_ops;
 
@@ -114,8 +104,7 @@ static struct mptcpd_plugin_ops const *_default_ops;
  * @note There is a TOCTOU race condition between this directory
  *       permissions check and subsequent calls to functions that
  *       access the given directory @a dir, such as the call to
- *       @c l_plugin_load().  There is currently no way to avoid that
- *       with the existing ELL API.
+ *       @c load_plugins().
  */
 static bool check_directory_perms(char const *dir)
 {

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -311,6 +311,13 @@ static int load_plugins(char const *dir, struct mptcpd_pm *pm)
 
         DIR *const ds = fdopendir(fd);
 
+        if (unlikely(ds == NULL)) {
+                report_error(errno,
+                             "fdopendir() on plugin directory failed");
+
+                return -1;
+        }
+
         errno = 0;
         for (struct dirent const *d = readdir(ds);
              d != NULL;

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -225,27 +225,6 @@ static void init_plugin(void *data, void *user_data)
                        p->desc->name);
 }
 
-static bool file_ends_in_so(char const *filename)
-{
-        static char const so[] = ".so";
-
-        /*
-          strlen(".so") == 3, which is the expected position of the
-          period relative to the end of the plugin filename.
-        */
-        static size_t const ppos = L_ARRAY_SIZE(so) - 1;
-
-        size_t const len = strlen(filename);
-
-        /*
-          The last three characters in the filename should be the
-          ".so" extension.
-        */
-        char const *const ext = filename + len - ppos;
-
-        return strcmp(ext, so) == 0;
-}
-
 static void load_plugin(char const *filename)
 {
         void *const handle = dlopen(filename, RTLD_NOW);
@@ -336,7 +315,7 @@ static int load_plugins(char const *dir, struct mptcpd_pm *pm)
              d != NULL;
              d = readdir(ds)) {
                 if ((d->d_type == DT_REG || d->d_type == DT_UNKNOWN)
-                    && file_ends_in_so(d->d_name)) {
+                    && l_str_has_suffix(d->d_name, ".so")) {
                         char *const path = l_strdup_printf("%s/%s",
                                                            dir,
                                                            d->d_name);

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -185,9 +185,8 @@ static struct l_queue *_plugin_infos;
  * @param[in] b         Existing plugin information.
  * @param[in] user_data User data (unused).
  *
- * @return Value greater than or equal to 0 if the new plugin should
- *         be inserted after the existing plugin in the list, and a
- *         negative value otherwise.
+ * @return -1 if the plugin should inserted before the existing
+ *         plugin, or 1 otherwise.
  *
  * @see @c l_queue_insert()
  */
@@ -202,10 +201,10 @@ static int compare_plugin_priority(void const *a,
 
         /*
           Cause "new" plugin to be inserted into the plugin list
-          before the "existing" plugin if its priority is higher than
-          the existing plugin priority.
+          before the "existing" plugin if its priority is higher
+          (numerically less) than the existing plugin priority.
         */
-        return new->desc->priority - existing->desc->priority;
+        return new->desc->priority < existing->desc->priority ? -1 : 1;
 }
 
 static void report_error(int error, char const *msg)

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -185,9 +185,9 @@ static struct l_queue *_plugin_infos;
  * @param[in] b         Existing plugin information.
  * @param[in] user_data User data (unused).
  *
- * @return Value greater than or equal to 0 if the new plugin should
- *         be inserted after the existing plugin in the list, and a
- *         negative value otherwise.
+ * @return Value greater than 0 if the new plugin should be inserted
+ *         after the existing plugin in the list, and a negative value
+ *         otherwise.
  */
 static int compare_plugin_priority(void const *a,
                                    void const *b,
@@ -201,11 +201,9 @@ static int compare_plugin_priority(void const *a,
         /*
           Cause "new" plugin to be inserted into the plugin list
           before the "existing" plugin it its priority is higher
-          than the existing plugin priority.
+          (lower value) than the existing plugin priority.
         */
-        return new->desc->priority > existing->desc->priority
-                ? -1   // Insert "new" before "existing".
-                :  1;  // Append to end of queue.
+        return new->desc->priority - existing->desc->priority;
 }
 
 static void report_error(int error, char const *msg)

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -13,11 +13,15 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <fcntl.h>
+#include <dirent.h>
+#include <dlfcn.h>
+#include <errno.h>
 #include <unistd.h>
 #include <assert.h>
 
+#include <ell/queue.h>
 #include <ell/hashmap.h>
-#include <ell/plugin.h>
 #include <ell/util.h>
 #include <ell/log.h>
 
@@ -50,6 +54,8 @@
  * A map of path manager plugins where the key is the plugin name and
  * the value is a pointer to a @c struct @c mptcpd_plugin_ops
  * instance.
+ *
+ * @todo Consider merging this map the @c plugin_infos queue.
  *
  * @note This is a static variable since ELL's plugin framework
  *       doesn't provide a way to pass user data to loaded plugins.
@@ -168,7 +174,235 @@ static struct mptcpd_plugin_ops const *token_to_ops(mptcpd_token_t token)
 //                Plugin Registration and Management
 // ----------------------------------------------------------------
 
-bool mptcpd_plugin_load(char const *dir, char const *default_name)
+/**
+ * @struct plugin_info
+ *
+ * @brief Plugin information
+ */
+struct plugin_info
+{
+        /// Handle returned from call to @c dlopen().
+        void *handle;
+
+        /// Plugin descriptor.
+        struct mptcpd_plugin_desc const *desc;
+};
+
+/// List of @c plugin_info objects.
+static struct l_queue *_plugin_infos;
+
+/**
+ * @brief Compare plugin priorities.
+ *
+ * @param[in] a         New      plugin information.
+ * @param[in] b         Existing plugin information.
+ * @param[in] user_data User data (unused).
+ *
+ * @return Value greater than 0 if the new plugin should be inserted
+ *         after the existing plugin in the list, and a negative value
+ *         otherwise.
+ */
+static int compare_plugin_priority(void const *a,
+                                   void const *b,
+                                   void *user_data)
+{
+        (void) user_data;
+
+        struct plugin_info const *const new      = a;
+        struct plugin_info const *const existing = b;
+
+        /*
+          Cause "new" plugin to be inserted into the plugin list
+          before the "existing" plugin it its priority is higher
+          (lower value) than the existing plugin priority.
+        */
+        return new->desc->priority - existing->desc->priority;
+}
+
+static void report_error(int error, char const *msg)
+{
+        char errmsg[80];
+        int const r =
+                strerror_r(error, errmsg, L_ARRAY_SIZE(errmsg));
+
+        l_error("%s: %s", msg, r == 0 ? errmsg : "<unknown error>");
+}
+
+static void init_plugin(void *data, void *user_data)
+{
+        struct plugin_info const *const p  = data;
+        struct mptcpd_pm         *const pm = user_data;
+
+        if (p->desc->init && p->desc->init(pm) != 0)
+                l_warn("Plugin \"%s\" failed to initialize",
+                       p->desc->name);
+}
+
+static bool file_ends_in_so(char const *filename)
+{
+        static char const so[] = ".so";
+
+        /*
+          strlen(".so") == 3, which is the expected position of the
+          period relative to the end of the plugin filename.
+        */
+        static size_t const ppos = L_ARRAY_SIZE(so) - 1;
+
+        size_t const len = strlen(filename);
+
+        /*
+          The last three characters in the filename should be the
+          ".so" extension.
+        */
+        char const *const ext = filename + len - ppos;
+
+        return strcmp(ext, so) == 0;
+}
+
+static void load_plugin(char const *filename)
+{
+        void *const handle = dlopen(filename, RTLD_NOW);
+
+        if (handle == NULL) {
+                l_error("%s", dlerror());
+                return;
+        }
+
+        void *const sym = dlsym(handle, L_STRINGIFY(MPTCPD_PLUGIN_SYM));
+
+        if (sym == NULL) {
+                l_error("%s", dlerror());
+                dlclose(handle);
+                return;
+        }
+
+        struct mptcpd_plugin_desc const *const desc = sym;
+
+        /**
+         * @note We assume that plugin names stored in the plugin
+         *       descriptor will be unique .  Path management events
+         *       could potentially be dispatched to the wrong plugin
+         *       with the same name, otherwise.
+         */
+        // Require a plugin name since we map it plugin operations.
+        if (desc->name == NULL) {
+                l_error("No plugin name specified in %s", filename);
+                dlclose(handle);
+                return;
+        }
+
+        struct plugin_info *const p = l_new(struct plugin_info, 1);
+        p->handle = handle;
+        p->desc   = desc;
+
+        // Register plugin.
+        if (!l_queue_insert(_plugin_infos,
+                            p,
+                            compare_plugin_priority,
+                            NULL)) {
+                /*
+                  We should never get here.  The only way to get here
+                  is if either the l_queue pointer argument,
+                  i.e. _plugin_infos, is NULL or if the comparison
+                  function argument is NULL.
+                */
+                l_error("Unexpected error registering plugin \"%s\"",
+                        filename);
+                l_free(p);
+                dlclose(handle);
+        }
+
+        /*
+          Initialization will be performed after all plugins are
+          loaded to taken into account plugin priority.
+        */
+}
+
+static int load_plugins(char const *dir, struct mptcpd_pm *pm)
+{
+        /**
+         * @note It would be simpler to implement this function in
+         *       terms of @c glob() but that introduces a TOCTOU race
+         *       condition between the @c glob() call and subsequent
+         *       calls to @c dlopen().  The below approach closes to
+         *       the TOCTOU race condition.
+         */
+
+        int const fd = open(dir, O_RDONLY | O_DIRECTORY);
+
+        if (fd == -1) {
+                report_error(errno, "Unable to open plugin directory");
+
+                return -1;
+        }
+
+        DIR *const ds = fdopendir(fd);
+
+        errno = 0;
+        for (struct dirent const *d = readdir(ds);
+             d != NULL;
+             d = readdir(ds)) {
+                if ((d->d_type == DT_REG || d->d_type == DT_UNKNOWN)
+                    && file_ends_in_so(d->d_name)) {
+                        char *const path = l_strdup_printf("%s/%s",
+                                                           dir,
+                                                           d->d_name);
+                        load_plugin(path);
+                        l_free(path);
+                }
+
+                // Reset to detect error on NULL readdir().
+                errno = 0;
+        }
+
+        int const error = errno;
+
+        (void) closedir(ds);
+
+        /**
+         * @todo Should a readdir() error from above be considered
+         *       fatal?
+         */
+        if (error != 0)
+                report_error(error, "Error during plugin directory read");
+
+        // Initialize all load plugins.
+        l_queue_foreach(_plugin_infos, init_plugin, pm);
+
+        return error;  // 0 on success
+}
+
+static bool unload_plugin(void *data, void *user_data)
+{
+        struct plugin_info *const p  = data;
+        struct mptcpd_pm   *const pm = user_data;
+
+        if (p->desc->exit)
+                p->desc->exit(pm);
+
+        dlclose(p->handle);
+        l_free(p);
+
+        return true;
+}
+
+static void unload_plugins(struct mptcpd_pm *pm)
+{
+        /*
+          Unload plugins in the reverse order in which they were
+          loaded.
+        */
+        if (!l_queue_reverse(_plugin_infos))
+                return;  // Empty queue
+
+        (void) l_queue_foreach_remove(_plugin_infos, unload_plugin, pm);
+        l_queue_destroy(_plugin_infos, NULL);
+        _plugin_infos = NULL;
+}
+
+bool mptcpd_plugin_load(char const *dir,
+                        char const *default_name,
+                        struct mptcpd_pm *pm)
 {
         if (dir == NULL) {
                 l_error("No plugin directory specified.");
@@ -179,8 +413,17 @@ bool mptcpd_plugin_load(char const *dir, char const *default_name)
         if (!check_directory_perms(dir))
                 return false;
 
+        if (_plugin_infos == NULL)
+                _plugin_infos = l_queue_new();
+
         if (_pm_plugins == NULL) {
                 _pm_plugins = l_hashmap_string_new();
+
+                /*
+                  No need to check for NULL since
+                  l_hashmap_string_new() abort()s on memory allocation
+                  failure.
+                */
 
                 if (default_name != NULL) {
                         size_t const len = L_ARRAY_SIZE(_default_name);
@@ -197,26 +440,8 @@ bool mptcpd_plugin_load(char const *dir, char const *default_name)
                                        len);
                 }
 
-                /*
-                  No need to check for NULL since
-                  l_hashmap_string_new() abort()s on memory allocation
-                  failure.
-                */
-
-                char *const pattern = l_strdup_printf("%s/*.so", dir);
-
-                // l_strdup_printf() abort()s on failure.
-
-                // All mptcpd plugins are expected to use this symbol
-                // in their L_PLUGIN_DEFINE() macro call.
-                static char const symbol[] =
-                        L_STRINGIFY(MPTCPD_PLUGIN_DESC);
-
-                l_plugin_load(pattern, symbol, VERSION);
-
-                l_free(pattern);
-
-                if (l_hashmap_isempty(_pm_plugins)) {
+                if (load_plugins(dir, pm) != 0
+                    || l_hashmap_isempty(_pm_plugins)) {
                         l_hashmap_destroy(_pm_plugins, NULL);
                         _pm_plugins = NULL;
 
@@ -246,7 +471,7 @@ bool mptcpd_plugin_load(char const *dir, char const *default_name)
         return !l_hashmap_isempty(_pm_plugins);
 }
 
-void mptcpd_plugin_unload(void)
+void mptcpd_plugin_unload(struct mptcpd_pm *pm)
 {
         /**
          * @note This isn't thread-safe.  We'll need a lock if we ever
@@ -262,7 +487,7 @@ void mptcpd_plugin_unload(void)
         _default_ops = NULL;
         memset(_default_name, 0, sizeof(_default_name));
 
-        l_plugin_unload();
+        unload_plugins(pm);
 }
 
 bool mptcpd_plugin_register_ops(char const *name,

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -185,9 +185,11 @@ static struct l_queue *_plugin_infos;
  * @param[in] b         Existing plugin information.
  * @param[in] user_data User data (unused).
  *
- * @return Value greater than 0 if the new plugin should be inserted
- *         after the existing plugin in the list, and a negative value
- *         otherwise.
+ * @return Value greater than or equal to 0 if the new plugin should
+ *         be inserted after the existing plugin in the list, and a
+ *         negative value otherwise.
+ *
+ * @see @c l_queue_insert()
  */
 static int compare_plugin_priority(void const *a,
                                    void const *b,
@@ -200,8 +202,8 @@ static int compare_plugin_priority(void const *a,
 
         /*
           Cause "new" plugin to be inserted into the plugin list
-          before the "existing" plugin it its priority is higher
-          (lower value) than the existing plugin priority.
+          before the "existing" plugin if its priority is higher than
+          the existing plugin priority.
         */
         return new->desc->priority - existing->desc->priority;
 }

--- a/plugins/path_managers/addr_adv.c
+++ b/plugins/path_managers/addr_adv.c
@@ -67,8 +67,10 @@ static struct mptcpd_plugin_ops const pm_ops = {
         .delete_local_address = addr_adv_delete_local_address
 };
 
-static int addr_adv_init(void)
+static int addr_adv_init(struct mptcpd_pm *pm)
 {
+        (void) pm;
+
         static char const name[] = "addr_adv";
 
         if (!mptcpd_plugin_register_ops(name, &pm_ops)) {
@@ -85,20 +87,20 @@ static int addr_adv_init(void)
         return 0;
 }
 
-static void addr_adv_exit(void)
+static void addr_adv_exit(struct mptcpd_pm *pm)
 {
+        (void) pm;
+
         mptcpd_idm_destroy(_idm);
 
         l_info("MPTCP address advertiser path manager exited.");
 }
 
-L_PLUGIN_DEFINE(MPTCPD_PLUGIN_DESC,
-                addr_adv,
-                "Address advertiser path manager",
-                VERSION,
-                L_PLUGIN_PRIORITY_DEFAULT,
-                addr_adv_init,
-                addr_adv_exit)
+MPTCPD_PLUGIN_DEFINE(addr_adv,
+                     "Address advertiser path manager",
+                     MPTCPD_PLUGIN_PRIORITY_DEFAULT,
+                     addr_adv_init,
+                     addr_adv_exit)
 
 
 /*

--- a/plugins/path_managers/addr_adv.c
+++ b/plugins/path_managers/addr_adv.c
@@ -11,7 +11,6 @@
 # include <mptcpd/config-private.h>
 #endif
 
-#include <ell/plugin.h>
 #include <ell/util.h>  // For L_STRINGIFY needed by ELL log macros.
 #include <ell/log.h>
 

--- a/plugins/path_managers/sspi.c
+++ b/plugins/path_managers/sspi.c
@@ -793,8 +793,10 @@ static struct mptcpd_plugin_ops const pm_ops = {
         .subflow_priority       = sspi_subflow_priority
 };
 
-static int sspi_init(void)
+static int sspi_init(struct mptcpd_pm *pm)
 {
+        (void) pm;
+
         // Create list of connection tokens on each network interface.
         sspi_interfaces = l_queue_new();
 
@@ -814,20 +816,20 @@ static int sspi_init(void)
         return 0;
 }
 
-static void sspi_exit(void)
+static void sspi_exit(struct mptcpd_pm *pm)
 {
+        (void) pm;
+
         l_queue_destroy(sspi_interfaces, sspi_interface_info_destroy);
 
         l_info("MPTCP single-subflow-per-interface path manager exited.");
 }
 
-L_PLUGIN_DEFINE(MPTCPD_PLUGIN_DESC,
-                sspi,
-                "Single-subflow-per-interface path manager",
-                VERSION,
-                L_PLUGIN_PRIORITY_DEFAULT,
-                sspi_init,
-                sspi_exit)
+MPTCPD_PLUGIN_DEFINE(sspi,
+                     "Single-subflow-per-interface path manager",
+                     MPTCPD_PLUGIN_PRIORITY_DEFAULT,
+                     sspi_init,
+                     sspi_exit)
 
 
 /*

--- a/plugins/path_managers/sspi.c
+++ b/plugins/path_managers/sspi.c
@@ -17,7 +17,6 @@
 
 #include <netinet/in.h>
 
-#include <ell/plugin.h>
 #include <ell/util.h>  // For L_STRINGIFY needed by l_error().
 #include <ell/log.h>
 #include <ell/queue.h>

--- a/src/path_manager.c
+++ b/src/path_manager.c
@@ -1126,7 +1126,8 @@ struct mptcpd_pm *mptcpd_pm_create(struct mptcpd_config const *config)
          *      @c mptcpd_plugin_unload() is called.
          */
         if (!mptcpd_plugin_load(config->plugin_dir,
-                                config->default_plugin)) {
+                                config->default_plugin,
+                                pm)) {
                 l_error("Unable to load path manager plugins.");
 
                 return NULL;
@@ -1145,7 +1146,7 @@ void mptcpd_pm_destroy(struct mptcpd_pm *pm)
          *      exit, or at least after the last @c mptcpd_pm object
          *      has been destroyed.
          */
-        mptcpd_plugin_unload();
+        mptcpd_plugin_unload(pm);
 
         mptcpd_nm_destroy(pm->nm);
         l_timeout_remove(pm->timeout);

--- a/tests/plugins/noop/noop.c
+++ b/tests/plugins/noop/noop.c
@@ -4,10 +4,9 @@
  *
  * @brief MPTCP test plugin.
  *
- * Copyright (c) 2019, Intel Corporation
+ * Copyright (c) 2019-2020, Intel Corporation
  */
 
-#include <ell/plugin.h>
 #include <ell/util.h>  // For L_STRINGIFY needed by l_error().
 #include <ell/log.h>
 

--- a/tests/plugins/noop/noop.c
+++ b/tests/plugins/noop/noop.c
@@ -118,8 +118,10 @@ static struct mptcpd_plugin_ops const pm_ops = {
         .subflow_priority       = plugin_noop_subflow_priority
 };
 
-static int plugin_noop_init(void)
+static int plugin_noop_init(struct mptcpd_pm *pm)
 {
+        (void) pm;
+
         static char const name[] = TEST_PLUGIN;
 
         if (!mptcpd_plugin_register_ops(name, &pm_ops)) {
@@ -132,17 +134,16 @@ static int plugin_noop_init(void)
         return 0;
 }
 
-static void plugin_noop_exit(void)
+static void plugin_noop_exit(struct mptcpd_pm *pm)
 {
+        (void) pm;
 }
 
-L_PLUGIN_DEFINE(MPTCPD_PLUGIN_DESC,
-                plugin_noop,
-                "test plugin noop",
-                VERSION,
-                L_PLUGIN_PRIORITY_DEFAULT,
-                plugin_noop_init,
-                plugin_noop_exit)
+MPTCPD_PLUGIN_DEFINE(plugin_noop,
+                     "test plugin noop",
+                     MPTCPD_PLUGIN_PRIORITY_DEFAULT,
+                     plugin_noop_init,
+                     plugin_noop_exit)
 
 
 /*

--- a/tests/plugins/priority/one.c
+++ b/tests/plugins/priority/one.c
@@ -207,7 +207,7 @@ static void plugin_one_exit(struct mptcpd_pm *pm)
 
 MPTCPD_PLUGIN_DEFINE(plugin_one,
                      "test plugin one",
-                     MPTCPD_PLUGIN_PRIORITY_LOW,  // favorable priority
+                     MPTCPD_PLUGIN_PRIORITY_HIGH,  // favorable priority
                      plugin_one_init,
                      plugin_one_exit)
 

--- a/tests/plugins/priority/one.c
+++ b/tests/plugins/priority/one.c
@@ -207,7 +207,7 @@ static void plugin_one_exit(struct mptcpd_pm *pm)
 
 MPTCPD_PLUGIN_DEFINE(plugin_one,
                      "test plugin one",
-                     MPTCPD_PLUGIN_PRIORITY_HIGH,  // favorable priority
+                     MPTCPD_PLUGIN_PRIORITY_LOW,  // favorable priority
                      plugin_one_init,
                      plugin_one_exit)
 

--- a/tests/plugins/priority/one.c
+++ b/tests/plugins/priority/one.c
@@ -4,14 +4,13 @@
  *
  * @brief MPTCP test plugin.
  *
- * Copyright (c) 2019, Intel Corporation
+ * Copyright (c) 2019-2020, Intel Corporation
  */
 
 #undef NDEBUG
 
 #include <assert.h>
 
-#include <ell/plugin.h>
 #include <ell/util.h>  // For L_STRINGIFY needed by l_error().
 #include <ell/log.h>
 

--- a/tests/plugins/priority/one.c
+++ b/tests/plugins/priority/one.c
@@ -163,8 +163,10 @@ static struct mptcpd_plugin_ops const pm_ops = {
         .subflow_priority       = plugin_one_subflow_priority
 };
 
-static int plugin_one_init(void)
+static int plugin_one_init(struct mptcpd_pm *pm)
 {
+        (void) pm;
+
         static char const name[] = TEST_PLUGIN;
 
         if (!mptcpd_plugin_register_ops(name, &pm_ops)) {
@@ -177,8 +179,10 @@ static int plugin_one_init(void)
         return 0;
 }
 
-static void plugin_one_exit(void)
+static void plugin_one_exit(struct mptcpd_pm *pm)
 {
+        (void) pm;
+
         /*
           This plugin should be called twice, once with the plugin name
           explicitly specified, and once as the default plugin with no
@@ -202,13 +206,11 @@ static void plugin_one_exit(void)
         call_count_reset(&call_count);
 }
 
-L_PLUGIN_DEFINE(MPTCPD_PLUGIN_DESC,
-                plugin_one,
-                "test plugin one",
-                VERSION,
-                L_PLUGIN_PRIORITY_LOW,  // favorable priority
-                plugin_one_init,
-                plugin_one_exit)
+MPTCPD_PLUGIN_DEFINE(plugin_one,
+                     "test plugin one",
+                     MPTCPD_PLUGIN_PRIORITY_LOW,  // favorable priority
+                     plugin_one_init,
+                     plugin_one_exit)
 
 
 /*

--- a/tests/plugins/priority/two.c
+++ b/tests/plugins/priority/two.c
@@ -192,7 +192,7 @@ static void plugin_two_exit(struct mptcpd_pm *pm)
 
 MPTCPD_PLUGIN_DEFINE(plugin_two,
                      "test plugin two",
-                     MPTCPD_PLUGIN_PRIORITY_LOW,  // unfavorable priority
+                     MPTCPD_PLUGIN_PRIORITY_HIGH,  // unfavorable priority
                      plugin_two_init,
                      plugin_two_exit)
 

--- a/tests/plugins/priority/two.c
+++ b/tests/plugins/priority/two.c
@@ -165,8 +165,10 @@ static struct mptcpd_plugin_ops const pm_ops = {
         .subflow_priority       = plugin_two_subflow_priority
 };
 
-static int plugin_two_init(void)
+static int plugin_two_init(struct mptcpd_pm *pm)
 {
+        (void) pm;
+
         static char const name[] = TEST_PLUGIN;
 
         if (!mptcpd_plugin_register_ops(name, &pm_ops)) {
@@ -179,21 +181,21 @@ static int plugin_two_init(void)
         return 0;
 }
 
-static void plugin_two_exit(void)
+static void plugin_two_exit(struct mptcpd_pm *pm)
 {
+        (void) pm;
+
         assert(call_count_is_sane(&call_count));
         assert(call_count_is_equal(&call_count, &test_count_2));
 
         call_count_reset(&call_count);
 }
 
-L_PLUGIN_DEFINE(MPTCPD_PLUGIN_DESC,
-                plugin_two,
-                "test plugin two",
-                VERSION,
-                L_PLUGIN_PRIORITY_HIGH,  // unfavorable priority
-                plugin_two_init,
-                plugin_two_exit)
+MPTCPD_PLUGIN_DEFINE(plugin_two,
+                     "test plugin two",
+                     MPTCPD_PLUGIN_PRIORITY_HIGH,  // unfavorable priority
+                     plugin_two_init,
+                     plugin_two_exit)
 
 
 /*

--- a/tests/plugins/priority/two.c
+++ b/tests/plugins/priority/two.c
@@ -192,7 +192,7 @@ static void plugin_two_exit(struct mptcpd_pm *pm)
 
 MPTCPD_PLUGIN_DEFINE(plugin_two,
                      "test plugin two",
-                     MPTCPD_PLUGIN_PRIORITY_HIGH,  // unfavorable priority
+                     MPTCPD_PLUGIN_PRIORITY_LOW,  // unfavorable priority
                      plugin_two_init,
                      plugin_two_exit)
 

--- a/tests/plugins/priority/two.c
+++ b/tests/plugins/priority/two.c
@@ -4,14 +4,13 @@
  *
  * @brief MPTCP test plugin.
  *
- * Copyright (c) 2019, Intel Corporation
+ * Copyright (c) 2019-2020, Intel Corporation
  */
 
 #undef NDEBUG
 
 #include <assert.h>
 
-#include <ell/plugin.h>
 #include <ell/util.h>  // For L_STRINGIFY needed by l_error().
 #include <ell/log.h>
 

--- a/tests/plugins/security/four.c
+++ b/tests/plugins/security/four.c
@@ -145,8 +145,10 @@ static struct mptcpd_plugin_ops const pm_ops = {
         .subflow_priority       = plugin_four_subflow_priority,
 };
 
-static int plugin_four_init(void)
+static int plugin_four_init(struct mptcpd_pm *pm)
 {
+        (void) pm;
+
         static char const name[] = TEST_PLUGIN;
 
         if (!mptcpd_plugin_register_ops(name, &pm_ops)) {
@@ -159,21 +161,21 @@ static int plugin_four_init(void)
         return 0;
 }
 
-static void plugin_four_exit(void)
+static void plugin_four_exit(struct mptcpd_pm *pm)
 {
+        (void) pm;
+
         assert(call_count_is_sane(&call_count));
         assert(call_count_is_equal(&call_count, &test_count_4));
 
         call_count_reset(&call_count);
 }
 
-L_PLUGIN_DEFINE(MPTCPD_PLUGIN_DESC,
-                plugin_four,
-                "test plugin four",
-                VERSION,
-                L_PLUGIN_PRIORITY_HIGH,  // Unfavorable priority.
-                plugin_four_init,
-                plugin_four_exit)
+MPTCPD_PLUGIN_DEFINE(plugin_four,
+                     "test plugin four",
+                     MPTCPD_PLUGIN_PRIORITY_HIGH,  // Unfavorable priority.
+                     plugin_four_init,
+                     plugin_four_exit)
 
 
 /*

--- a/tests/plugins/security/four.c
+++ b/tests/plugins/security/four.c
@@ -172,7 +172,7 @@ static void plugin_four_exit(struct mptcpd_pm *pm)
 
 MPTCPD_PLUGIN_DEFINE(plugin_four,
                      "test plugin four",
-                     MPTCPD_PLUGIN_PRIORITY_HIGH,  // Unfavorable priority.
+                     MPTCPD_PLUGIN_PRIORITY_LOW,  // Unfavorable priority.
                      plugin_four_init,
                      plugin_four_exit)
 

--- a/tests/plugins/security/four.c
+++ b/tests/plugins/security/four.c
@@ -172,7 +172,7 @@ static void plugin_four_exit(struct mptcpd_pm *pm)
 
 MPTCPD_PLUGIN_DEFINE(plugin_four,
                      "test plugin four",
-                     MPTCPD_PLUGIN_PRIORITY_LOW,  // Unfavorable priority.
+                     MPTCPD_PLUGIN_PRIORITY_HIGH,  // Unfavorable priority.
                      plugin_four_init,
                      plugin_four_exit)
 

--- a/tests/plugins/security/four.c
+++ b/tests/plugins/security/four.c
@@ -4,14 +4,13 @@
  *
  * @brief MPTCP test plugin.
  *
- * Copyright (c) 2019, Intel Corporation
+ * Copyright (c) 2019-2020, Intel Corporation
  */
 
 #undef NDEBUG
 
 #include <assert.h>
 
-#include <ell/plugin.h>
 #include <ell/util.h>  // For L_STRINGIFY needed by l_error().
 #include <ell/log.h>
 

--- a/tests/plugins/security/three.c
+++ b/tests/plugins/security/three.c
@@ -145,8 +145,10 @@ static struct mptcpd_plugin_ops const pm_ops = {
         .subflow_priority       = plugin_three_subflow_priority,
 };
 
-static int plugin_three_init(void)
+static int plugin_three_init(struct mptcpd_pm *pm)
 {
+        (void) pm;
+
         static char const name[] = TEST_PLUGIN;
 
         if (!mptcpd_plugin_register_ops(name, &pm_ops)) {
@@ -159,8 +161,10 @@ static int plugin_three_init(void)
         return 0;
 }
 
-static void plugin_three_exit(void)
+static void plugin_three_exit(struct mptcpd_pm *pm)
 {
+        (void) pm;
+
         struct plugin_call_count const count = { .new_connection = 0 };
 
         assert(call_count_is_sane(&call_count));
@@ -169,14 +173,12 @@ static void plugin_three_exit(void)
         call_count_reset(&call_count);
 }
 
-L_PLUGIN_DEFINE(MPTCPD_PLUGIN_DESC,
-                plugin_three,
-                "test plugin three",
-                VERSION,
-                L_PLUGIN_PRIORITY_DEFAULT,  // Between the other
-                                            // plugins.
-                plugin_three_init,
-                plugin_three_exit)
+MPTCPD_PLUGIN_DEFINE(plugin_three,
+                     "test plugin three",
+                     MPTCPD_PLUGIN_PRIORITY_DEFAULT,  // Between the
+                                                      // other plugins.
+                     plugin_three_init,
+                     plugin_three_exit)
 
 
 /*

--- a/tests/plugins/security/three.c
+++ b/tests/plugins/security/three.c
@@ -4,14 +4,13 @@
  *
  * @brief MPTCP test plugin.
  *
- * Copyright (c) 2019, Intel Corporation
+ * Copyright (c) 2019-2020, Intel Corporation
  */
 
 #undef NDEBUG
 
 #include <assert.h>
 
-#include <ell/plugin.h>
 #include <ell/util.h>  // For L_STRINGIFY needed by l_error().
 #include <ell/log.h>
 

--- a/tests/test-cxx-build.cpp
+++ b/tests/test-cxx-build.cpp
@@ -63,12 +63,14 @@ class test_plugin
 {
 public:
         test_plugin()
+                : pm(NULL)
         {
                 static char const dir[]            = TEST_PLUGIN_DIR;
                 static char const default_plugin[] = TEST_PLUGIN_FOUR;
+                struct mptcpd_pm *const pm = NULL;
 
                 bool const loaded =
-                        mptcpd_plugin_load(dir, default_plugin);
+                        mptcpd_plugin_load(dir, default_plugin, this->pm);
                 assert(loaded);
 
                 call_plugin_ops(&test_count_4,
@@ -80,11 +82,13 @@ public:
                                 test_backup_4);
         }
 
-        ~test_plugin() { mptcpd_plugin_unload(); }
+        ~test_plugin() { mptcpd_plugin_unload(this->pm); }
 
 private:
         test_plugin(test_plugin const &);
         void operator=(test_plugin const &);
+private:
+        struct mptcpd_pm *const pm;
 };
 
 


### PR DESCRIPTION
ELL dropped its plugin API after release 0.33.  Revise the mptcpd plugin framework to instead use the standard `dlopen()` / `dlsym()` / `dlclose()` family of functions.  Take the opportunity to pass a pointer to the `struct mptcpd` object to the plugin `init` and `exit` functions so that plugins may have earlier and later, respectively, opportunities to perform calls through the mptcpd main path manager interface.  Fixes #84.
