### PR TITLE
Add a global address ID manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ tests/test-path-manager
 tests/test-commands
 tests/test-configuration
 tests/test-cxx-build
+tests/test-id-manager
 tests/*.log
 tests/*.trs
 tests/test-suite.log

--- a/include/mptcpd/id_manager.h
+++ b/include/mptcpd/id_manager.h
@@ -20,7 +20,12 @@ extern "C" {
 struct mptcpd_idm;
 struct sockaddr;
 
-/// Create MPTCP address ID manager.
+/**
+ * @brief Create MPTCP address ID manager.
+ *
+ * @return Pointer to MPTCP address ID manager on success.  @c NULL on
+ *         failure.
+ */
 MPTCPD_API struct mptcpd_idm *mptcpd_idm_create(void);
 
 /**

--- a/include/mptcpd/path_manager.h
+++ b/include/mptcpd/path_manager.h
@@ -229,6 +229,16 @@ MPTCPD_API int mptcpd_pm_remove_subflow(
 MPTCPD_API struct mptcpd_nm const *
 mptcpd_pm_get_nm(struct mptcpd_pm const *pm);
 
+/**
+ * @brief Get pointer to the underlying MPTCP address ID manager.
+ *
+ * @param[in] pm Mptcpd path manager.
+ *
+ * @return Mptcpd MPTCP address ID manager.
+ */
+MPTCPD_API struct mptcpd_idm *
+mptcpd_pm_get_idm(struct mptcpd_pm const *pm);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/mptcpd/path_manager_private.h
+++ b/include/mptcpd/path_manager_private.h
@@ -27,6 +27,7 @@ struct mptcpd_pm_cmd_ops;
 struct mptcpd_addr_info;
 struct mptcpd_limit;
 struct mptcpd_nm;
+struct mptcpd_idm;
 
 /**
  * @struct mptcpd_pm path_manager_private.h <mptcpd/path_manager_private.h>
@@ -76,6 +77,14 @@ struct mptcpd_pm
          * detect changes to network devices.
          */
         struct mptcpd_nm *nm;
+
+        /**
+         * @brief MPTCP address ID manager.
+         *
+         * Manager that maps IP addresses to MPTCP address IDs, and
+         * generated IDs as needed..
+         */
+        struct mptcpd_idm *idm;
 };
 
 /**

--- a/lib/path_manager.c
+++ b/lib/path_manager.c
@@ -256,6 +256,11 @@ struct mptcpd_nm const * mptcpd_pm_get_nm(struct mptcpd_pm const *pm)
         return pm->nm;
 }
 
+struct mptcpd_idm * mptcpd_pm_get_idm(struct mptcpd_pm const *pm)
+{
+        return pm->idm;
+}
+
 
 /*
   Local Variables:

--- a/plugins/path_managers/addr_adv.c
+++ b/plugins/path_managers/addr_adv.c
@@ -21,13 +21,12 @@
 #include <mptcpd/plugin.h>
 
 
-static struct mptcpd_idm *_idm;
-
 static void addr_adv_new_local_address(struct mptcpd_interface const *i,
                                        struct sockaddr const *sa,
                                        struct mptcpd_pm *pm)
 {
-        mptcpd_aid_t const id = mptcpd_idm_get_id(_idm, sa);
+        struct mptcpd_idm *const idm = mptcpd_pm_get_idm(pm);
+        mptcpd_aid_t const id = mptcpd_idm_get_id(idm, sa);
 
         if (id == 0) {
                 l_error("Unable to map addr to ID.");
@@ -48,7 +47,8 @@ static void addr_adv_delete_local_address(
 {
         (void) i;
 
-        mptcpd_aid_t const id = mptcpd_idm_remove_id(_idm, sa);
+        struct mptcpd_idm *const idm = mptcpd_pm_get_idm(pm);
+        mptcpd_aid_t const id = mptcpd_idm_remove_id(idm, sa);
 
         if (id == 0) {
                 // Not necessarily an error.
@@ -78,8 +78,6 @@ static int addr_adv_init(void)
                 return -1;
         }
 
-        _idm = mptcpd_idm_create();
-
         l_info("MPTCP address advertiser path manager initialized.");
 
         return 0;
@@ -87,8 +85,6 @@ static int addr_adv_init(void)
 
 static void addr_adv_exit(void)
 {
-        mptcpd_idm_destroy(_idm);
-
         l_info("MPTCP address advertiser path manager exited.");
 }
 


### PR DESCRIPTION
Add a "global" MPTCP address ID manager instance to mitigate potential duplicate MPTCP address IDs between plugins, as well as to make it easier to detect and handle changes in the kernel's own address ID state in the future.  Plugins may access the gobal MPTCP address ID manager through the new `mptcpd_pm_get_idm()` function.



Fixes #88.