### PR TITLE
src: Load plugins after netlink PM is available

### DIFF
--- a/include/mptcpd/path_manager_private.h
+++ b/include/mptcpd/path_manager_private.h
@@ -4,7 +4,7 @@
  *
  * @brief mptcpd path manager private interface.
  *
- * Copyright (c) 2017-2020, Intel Corporation
+ * Copyright (c) 2017-2021, Intel Corporation
  */
 
 #ifndef MPTCPD_PATH_MANAGER_PRIVATE_H

--- a/include/mptcpd/path_manager_private.h
+++ b/include/mptcpd/path_manager_private.h
@@ -43,6 +43,9 @@ struct mptcpd_pm
         /**
          * @privatesection
          */
+        /// Mptcpd configuration.
+        struct mptcpd_config const *config;
+
         ///
         struct mptcpd_pm_cmd_ops const *cmd_ops;
 

--- a/src/path_manager.c
+++ b/src/path_manager.c
@@ -1209,6 +1209,7 @@ struct mptcpd_pm *mptcpd_pm_create(struct mptcpd_config const *config)
                                       family_appeared,
                                       data,
                                       l_free)) {
+                l_free(data);
                 mptcpd_pm_destroy(pm);
                 l_error("Unable to watch or request \"%s\" "
                         "generic netlink family.",

--- a/src/path_manager.c
+++ b/src/path_manager.c
@@ -935,8 +935,6 @@ static void dump_addrs_callback(struct mptcpd_addr_info const *info,
         char addrstr[INET6_ADDRSTRLEN];  // Long enough for both IPv4
                                          // and IPv6 addresses.
 
-
-
         struct mptcpd_idm *const idm = callback_data;
 
         /**

--- a/src/path_manager.c
+++ b/src/path_manager.c
@@ -1041,6 +1041,19 @@ static void family_appeared(struct l_genl_family_info const *info,
                 complete_mptcp_org_kernel_pm_init(pm);
 
         complete_pm_init(pm);
+        /**
+         * @bug Mptcpd plugins should only be loaded once at process
+         *      start.  The @c mptcpd_plugin_load() function only
+         *      loads the functions once, and only reloads after
+         *      @c mptcpd_plugin_unload() is called.
+         */
+        if (!mptcpd_plugin_load(config->plugin_dir,
+                                config->default_plugin,
+                                pm)) {
+                l_error("Unable to load path manager plugins.");
+
+                return NULL;
+        }
 }
 
 /**
@@ -1204,20 +1217,6 @@ struct mptcpd_pm *mptcpd_pm_create(struct mptcpd_config const *config)
         if (pm->idm == NULL) {
                 mptcpd_pm_destroy(pm);
                 l_error("Unable to create ID manager.");
-                return NULL;
-        }
-
-        /**
-         * @bug Mptcpd plugins should only be loaded once at process
-         *      start.  The @c mptcpd_plugin_load() function only
-         *      loads the functions once, and only reloads after
-         *      @c mptcpd_plugin_unload() is called.
-         */
-        if (!mptcpd_plugin_load(config->plugin_dir,
-                                config->default_plugin,
-                                pm)) {
-                l_error("Unable to load path manager plugins.");
-
                 return NULL;
         }
 

--- a/src/path_manager.c
+++ b/src/path_manager.c
@@ -1070,6 +1070,10 @@ static void family_appeared(struct l_genl_family_info const *info,
                                 config->default_plugin,
                                 pm)) {
                 l_error("Unable to load path manager plugins.");
+
+                l_free(data);
+                mptcpd_pm_destroy(pm);
+
                 exit(EXIT_FAILURE);
         }
 }


### PR DESCRIPTION
Defer plugin load until after the generic netlink family for the
netlink path manager is ready for use since the recent plugin
framework updates make it possible for path management related calls
to be invoked during plugin initialization.  This also effectively
ensures that the mptcpd path manager bridge is always ready, obviating
the need to poll for readiness by plugins.