### PR TITLE
Drop addr_info length from mptcpd_pm_dump_addrs().

### DIFF
--- a/include/mptcpd/path_manager.h
+++ b/include/mptcpd/path_manager.h
@@ -105,14 +105,15 @@ MPTCPD_API int mptcpd_pm_get_addr(struct mptcpd_pm *pm,
  * @brief Get list (array) of MPTCP network addresses.
  *
  * @param[in] pm       The mptcpd path manager object.
- * @param[in] callback Function to be called when a dump of network
- *                     addresses has been retrieved.
+ * @param[in] callback Function to be called when a network address
+ *                     has been retrieved.  This function will be
+ *                     called once per dumped network address.
  * @param[in] data     Data to be passed to the @a callback function.
  *
  * @return @c 0 if operation was successful. -1 or @c errno otherwise.
  */
 MPTCPD_API int mptcpd_pm_dump_addrs(struct mptcpd_pm *pm,
-                                    mptcpd_pm_dump_addrs_cb callback,
+                                    mptcpd_pm_get_addr_cb callback,
                                     void *data);
 
 /**

--- a/include/mptcpd/path_manager_private.h
+++ b/include/mptcpd/path_manager_private.h
@@ -176,7 +176,7 @@ struct mptcpd_pm_cmd_ops
          *         otherwise.
          */
         int (*dump_addrs)(struct mptcpd_pm *pm,
-                          mptcpd_pm_dump_addrs_cb callback,
+                          mptcpd_pm_get_addr_cb callback,
                           void *data);
 
         /**

--- a/include/mptcpd/types.h
+++ b/include/mptcpd/types.h
@@ -61,33 +61,17 @@ struct mptcpd_limit
  * @brief Type of function called when an address is available.
  *
  * The mptcpd path manager will call a function of this type when
- * the result of calling @c mptcpd_pm_get_addr() is available.
+ * the result of calling @c mptcpd_pm_get_addr() or
+ * @c mptcpd_pm_dump_addrs() is available.
  *
  * @param[in]     info          Network address information.  @c NULL
  *                              on error.
  * @param[in,out] callback_data Data provided by the caller of
- *                              @c mptcpd_pm_get_addr().
+ *                              @c mptcpd_pm_get_addr() or
+ *                              @c mptcpd_pm_dump_addrs().
  */
 typedef void (*mptcpd_pm_get_addr_cb)(struct mptcpd_addr_info const *info,
                                       void *callback_data);
-
-/**
- * @brief Type of function called when an address dump is available.
- *
- * The mptcpd path manager will call a function of this type when
- * the result of calling @c mptcpd_pm_dump_addrs() is available.
- *
- * @param[in]     info          Array of network address
- *                              information. @c NULL on error.
- * @param[in]     len           Length of the @a info array.  Zero on
- *                              error.
- * @param[in,out] callback_data Data provided by the caller of
- *                              @c mptcpd_pm_dump_addrs().
- */
-typedef void (*mptcpd_pm_dump_addrs_cb)(
-        struct mptcpd_addr_info const *info,
-        size_t len,
-        void *callback_data);
 
 /**
  * @brief Type of function called when MPTCP resource limit are available.

--- a/lib/path_manager.c
+++ b/lib/path_manager.c
@@ -108,7 +108,7 @@ int mptcpd_pm_get_addr(struct mptcpd_pm *pm,
 }
 
 int mptcpd_pm_dump_addrs(struct mptcpd_pm *pm,
-                         mptcpd_pm_dump_addrs_cb callback,
+                         mptcpd_pm_get_addr_cb callback,
                          void *data)
 {
         if (pm == NULL || callback == NULL)

--- a/tests/test-commands.c
+++ b/tests/test-commands.c
@@ -104,7 +104,6 @@ static void get_addr_callback(struct mptcpd_addr_info const *info,
 }
 
 static void dump_addrs_callback(struct mptcpd_addr_info const *info,
-                                size_t len,
                                 void *user_data)
 {
         mptcpd_aid_t const id = L_PTR_TO_UINT(user_data);
@@ -115,13 +114,12 @@ static void dump_addrs_callback(struct mptcpd_addr_info const *info,
          *      previously added through @c mptcpd_pm_add_addr() would
          *      end up not being removed prior to test exit.
          */
-        assert(len == 1);
         assert(info != NULL);
-        assert(info[0].id == id);
+        assert(info->id == id);
 
         struct sockaddr const *const addr = laddr1;
         assert(sockaddr_is_equal(addr,
-                                 (struct sockaddr *) &info[0].addr));
+                                 (struct sockaddr *) &info->addr));
 }
 
 static void get_limits_callback(struct mptcpd_limit const *limits,


### PR DESCRIPTION
There is no need for a `mptcpd_addr_info` array length argument in the  `dump_addrs` callback since the kernel sends multiple replies containing a single dumped `addr`, rather than a single reply with multiple dumped `addrs`.
