### PR TITLE
sspi: Fix network interface index/addr lookup.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,5 @@
+- A network interface lookup problem in the "sspi" plugin was fixed.
+
 25 January 2021 - mptcpd 0.6
 
 - Mptcpd now supports versions of the Embedded Linux Library (ELL)

--- a/plugins/path_managers/sspi.c
+++ b/plugins/path_managers/sspi.c
@@ -218,7 +218,7 @@ static void sspi_get_index(struct mptcpd_interface const *interface,
         */
         if (l_queue_find(interface->addrs,
                          sspi_sockaddr_match,
-                         &callback_data->addr) != NULL) {
+                         callback_data->addr) != NULL) {
                 callback_data->index = interface->index;
         } else {
                 /*


### PR DESCRIPTION
The reverse lookup of a network interface index from an IP address
failed due to passing the address of a pointer to a sockaddr to the
lookup function rather than the pointer itself.