### PR TITLE
Drop use of ELL likely()/unlikely() macros.

### DIFF
--- a/lib/network_monitor.c
+++ b/lib/network_monitor.c
@@ -715,7 +715,7 @@ insert_addr_return(struct mptcpd_interface *interface,
 {
         struct sockaddr *addr = mptcpd_sockaddr_create(rtm_addr);
 
-        if (unlikely(addr == NULL)
+        if (addr == NULL
             || !l_queue_insert(interface->addrs,
                                addr,
                                mptcpd_sockaddr_compare,

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -150,7 +150,7 @@ static struct mptcpd_plugin_ops const *token_to_ops(mptcpd_token_t token)
                 l_hashmap_lookup(_token_to_ops,
                                  L_UINT_TO_PTR(token));
 
-        if (unlikely(ops == NULL))
+        if (ops == NULL)
                 l_error("Unable to match token to plugin.");
 
         return ops;
@@ -310,7 +310,7 @@ static int load_plugins(char const *dir, struct mptcpd_pm *pm)
 
         DIR *const ds = fdopendir(fd);
 
-        if (unlikely(ds == NULL)) {
+        if (ds == NULL) {
                 report_error(errno,
                              "fdopendir() on plugin directory failed");
 

--- a/src/netlink_pm_mptcp_org.c
+++ b/src/netlink_pm_mptcp_org.c
@@ -67,7 +67,7 @@ static void check_kernel_mptcp_path_manager(void)
 
         fclose(f);
 
-        if (likely(n == 1)) {
+        if (n == 1) {
                 if (strcmp(pm, "netlink") != 0) {
                         /*
                           "netlink" could be set as the default.  It


### PR DESCRIPTION
ELL 0.39 moved the likely() and unlikely() macros to a new
<ell/useful.h> header.  Rather than conditionally include that header
for ELL >= 0.39 just drop use of those macros in mptcpd.  They didn't
provide a performance benefit in the areas of mptcpd in which they
were used so don't bother using them.