### PR TITLE
include: Clarify server- vs client-oriented.

### DIFF
--- a/include/mptcpd/path_manager.h
+++ b/include/mptcpd/path_manager.h
@@ -84,6 +84,13 @@ MPTCPD_API int mptcpd_pm_remove_addr(struct mptcpd_pm *pm,
                                      mptcpd_token_t token);
 
 /**
+ * @name Server-oriented Path Management Commands
+ *
+ * Server-oriented path management commands supported by the upstream
+ * Linux kernel.  Path management is handled by the kernel.
+ */
+//@{
+/**
  * @brief Get network address corresponding to an address ID.
  *
  * @param[in] pm       The mptcpd path manager object.
@@ -152,7 +159,15 @@ MPTCPD_API int mptcpd_pm_set_limits(struct mptcpd_pm *pm,
 MPTCPD_API int mptcpd_pm_get_limits(struct mptcpd_pm *pm,
                                     mptcpd_pm_get_limits_cb callback,
                                     void *data);
+//@}
 
+/**
+ * @name Client-oriented Path Management Commands
+ *
+ * Client-oriented path management commands that allow for
+ * per-connection path management.
+ */
+//@{
 /**
  * @brief Create a new subflow.
  *
@@ -218,6 +233,7 @@ MPTCPD_API int mptcpd_pm_remove_subflow(
         mptcpd_token_t token,
         struct sockaddr const *local_addr,
         struct sockaddr const *remote_addr);
+//@}
 
 /**
  * @brief Get pointer to the underlying network monitor.

--- a/include/mptcpd/private/path_manager.h
+++ b/include/mptcpd/private/path_manager.h
@@ -109,6 +109,14 @@ struct mptcpd_pm_cmd_ops
          * Path management common to both the upstream and
          * multipath-tcp.org Linux kernels.
          *
+         * @todo Consider splitting these commands into
+         *       server-oriented and client-oriented cases.  There
+         *       shouldn't be any overlap between these use cases.
+         */
+        //@{
+        /**
+         * @brief Advertise new network address to peers.
+         *
          * @param[in] pm    The mptcpd path manager object.
          * @param[in] addr  Local IP address and port to be advertised
          *                  through the MPTCP protocol @c ADD_ADDR
@@ -119,10 +127,6 @@ struct mptcpd_pm_cmd_ops
          * @param[in] index Network interface index (optional for
          *                  upstream Linux kernel).
          * @param[in] token MPTCP connection token.
-         */
-        //@{
-        /**
-         * @brief Advertise new network address to peers.
          */
         int (*add_addr)(struct mptcpd_pm *pm,
                         struct sockaddr const *addr,
@@ -140,9 +144,10 @@ struct mptcpd_pm_cmd_ops
         //@}
 
         /**
-         * @name Upstream Kernel Path Management Commands
+         * @name Server-oriented Path Management Commands
          *
-         * Path management commands supported by the upstream Linux
+         * Server-oriented path management commands supported by the
+         * upstream Linux kernel.  Path management is handled by the
          * kernel.
          */
         //@{
@@ -226,10 +231,10 @@ struct mptcpd_pm_cmd_ops
         //@}
 
         /**
-         * @name multipath-tcp.org kernel Path Management Commands
+         * @name Client-oriented Path Management Commands
          *
-         * Path management commands supported by the multipath-tcp.org
-         * Linux kernel.
+         * Client-oriented path management commands that allow for
+         * per-connection path management.
          */
         //@{
         /**


### PR DESCRIPTION
The upstream kernel's path management API exposes two types of path management commands, those more suited to servers and those more suited to clients (still a work-in-progress). Clarify documentation of server-oriented and client-oriented path managements command functions in libmptcpd.

Fixes #115.