### PR TITLE
configure: Update bug report address.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@
 AC_PREREQ([2.69])
 AC_INIT([mptcpd],
         [0.6],
-        [mptcp@lists.01.org],
+        [mptcp@lists.linux.dev],
         [],
         [https://01.org/multipath-tcp-linux])
 


### PR DESCRIPTION
Update bug report address to "mptcp@lists.linux.dev".  The previous
"mptcp@lists.01.org" mailing list will no longer be used.