### PR TITLE
configure: Update package URL.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9,7 +9,7 @@ AC_INIT([mptcpd],
         [0.6],
         [mptcp@lists.01.org],
         [],
-        [https://01.org/multipath-tcp-linux])
+        [https://github.com/intel/mptcpd])
 
 # ---------------------------------------------------------------
 # Libtool Based Library Versioning


### PR DESCRIPTION
Use the mptcpd GitHub URL "https://github.com/intel/mptcpd" instead of
the less used 01.org URL "https://01.org/multipath-tcp-linux".