### PR TITLE
Correct genl msg payload size calculation.

### DIFF
--- a/src/commands.h
+++ b/src/commands.h
@@ -23,6 +23,8 @@
 
 #define MPTCPD_NLA_ALIGN(v) (NLA_HDRLEN + NLA_ALIGN(sizeof(v)))
 #define MPTCPD_NLA_ALIGN_OPT(v) ((v) == 0 ? 0 : (MPTCPD_NLA_ALIGN(v)))
+#define MPTCPD_NLA_ALIGN_ADDR(v) \
+        (NLA_HDRLEN + NLA_ALIGN(mptcpd_get_addr_size(v)))
 
 
 #ifdef __cplusplus

--- a/src/netlink_pm_mptcp_org.c
+++ b/src/netlink_pm_mptcp_org.c
@@ -216,7 +216,7 @@ static int mptcp_org_add_addr(struct mptcpd_pm *pm,
                 MPTCPD_NLA_ALIGN(token)
                 + MPTCPD_NLA_ALIGN(id)
                 + MPTCPD_NLA_ALIGN(family)
-                + NLA_HDRLEN + NLA_ALIGN(mptcpd_get_addr_size(addr))
+                + MPTCPD_NLA_ALIGN_ADDR(addr)
                 + MPTCPD_NLA_ALIGN_OPT(port);
 
         struct l_genl_msg *const msg =
@@ -350,11 +350,11 @@ static int mptcp_org_add_subflow(struct mptcpd_pm *pm,
                 + MPTCPD_NLA_ALIGN(remote_address_id)
                 + (local_addr == NULL
                    ? 0
-                   : (NLA_HDRLEN + NLA_ALIGN(mptcpd_get_addr_size(local_addr))
+                   : (MPTCPD_NLA_ALIGN_ADDR(local_addr)
                       + (MPTCPD_NLA_ALIGN_OPT(local_port))))
                 + (remote_addr == NULL
                    ? 0
-                   : NLA_HDRLEN + NLA_ALIGN(mptcpd_get_addr_size(remote_addr))
+                   : MPTCPD_NLA_ALIGN_ADDR(remote_addr)
                    + MPTCPD_NLA_ALIGN(remote_port))
                 + MPTCPD_NLA_ALIGN(backup);
 
@@ -444,9 +444,9 @@ static int mptcp_org_set_backup(struct mptcpd_pm *pm,
         size_t const payload_size =
                 MPTCPD_NLA_ALIGN(token)
                 + MPTCPD_NLA_ALIGN(family)
-                + NLA_HDRLEN + NLA_ALIGN(mptcpd_get_addr_size(local_addr))
+                + MPTCPD_NLA_ALIGN_ADDR(local_addr)
                 + MPTCPD_NLA_ALIGN(local_port)
-                + NLA_HDRLEN + NLA_ALIGN(mptcpd_get_addr_size(remote_addr))
+                + MPTCPD_NLA_ALIGN_ADDR(remote_addr)
                 + MPTCPD_NLA_ALIGN(remote_port)
                 + MPTCPD_NLA_ALIGN(backup);
 
@@ -527,9 +527,9 @@ static int mptcp_org_remove_subflow(struct mptcpd_pm *pm,
         size_t const payload_size =
                 MPTCPD_NLA_ALIGN(token)
                 + MPTCPD_NLA_ALIGN(family)
-                + NLA_HDRLEN + NLA_ALIGN(mptcpd_get_addr_size(local_addr))
+                + MPTCPD_NLA_ALIGN_ADDR(local_addr)
                 + MPTCPD_NLA_ALIGN(local_port)
-                + NLA_HDRLEN + NLA_ALIGN(mptcpd_get_addr_size(remote_addr))
+                + MPTCPD_NLA_ALIGN_ADDR(remote_addr)
                 + MPTCPD_NLA_ALIGN(remote_port);
 
         struct l_genl_msg *const msg =

--- a/src/netlink_pm_upstream.c
+++ b/src/netlink_pm_upstream.c
@@ -369,11 +369,9 @@ static int upstream_add_addr(struct mptcpd_pm *pm,
         // Types chosen to match MPTCP genl API.
         uint16_t const family = mptcpd_get_addr_family(addr);
 
-        size_t const addr_size = mptcpd_get_addr_size(addr);
-
         size_t const payload_size =
                 MPTCPD_NLA_ALIGN(family)
-                + MPTCPD_NLA_ALIGN(addr_size)
+                + MPTCPD_NLA_ALIGN_ADDR(addr)
                 + MPTCPD_NLA_ALIGN_OPT(address_id)
                 + MPTCPD_NLA_ALIGN_OPT(flags)
                 + MPTCPD_NLA_ALIGN_OPT(index);


### PR DESCRIPTION
The generic netlink message payload size calculation for the upstream kernel `add_addr` command incorrectly used the size of the type used to hold the size of the `addr`, e.g. equivalent to `sizeof(size_t)`, instead of the actual size of the `addr`, `sizeof(struct in_addr)` or `sizeof(struct in6_addr)`.  The incorrect payload size calculation would only be obvious when using an IPv6 address.
