### PR TITLE
src: Fix ENOTSUP error for get_limits command.

### DIFF
--- a/src/netlink_pm_upstream.c
+++ b/src/netlink_pm_upstream.c
@@ -617,7 +617,7 @@ static int upstream_get_limits(struct mptcpd_pm *pm,
         cb->get_limits = callback;
         cb->data       = data;
 
-        return l_genl_family_dump(pm->family,
+        return l_genl_family_send(pm->family,
                                   msg,
                                   get_limits_callback,
                                   cb,     /* user data */


### PR DESCRIPTION
The get_limits PM command implementation incorrectly attempted to
perform a genl "dump" operation rather than the expect "doit".  Send
the command message via l_genl_family_send() instead of
l_genl_family_dump().  This corrects an ENOTSUP error issued by the
kernel when attempting to perform the MPTCP_PM_CMD_GET_LIMITS
command.