### PR TITLE
mptcpd 0.7

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,4 @@
-9 April 2021 - mptcpd 0.7
+13 April 2021 - mptcpd 0.7
 
 - MPTCP path management generic netlink events recently added to the
   upstream Linux kernel are now supported, and propagated to mptcpd
@@ -13,13 +13,14 @@
 
 - An incorrect buffer size calculation when calling
   mptcpd_pm_add_addr() when using an IPv6 addresses on platforms
-  running the upstream Linux kernel was fixed.
+  running the upstream Linux kernel was corrected.
 
 - An "operation not supported" error that occurred when attempting to
   retrieve MPTCP resource limits through the mptcpd_pm_get_limits()
   function was fixed.
 
-- A network interface lookup problem in the "sspi" plugin was fixed.
+- A network interface lookup problem in the "sspi" plugin was
+  corrected.
 
 - Building mptcpd against ELL 0.39 is now supported.
 

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,27 @@
+9 April 2021 - mptcpd 0.7
+
+- MPTCP path management generic netlink events recently added to the
+  upstream Linux kernel are now supported, and propagated to mptcpd
+  plugins.  The same API is also found in the multipath-tcp.org
+  kernel.  Differences between the two kernels are transparent to
+  mptcpd plugins.
+
+- Mptcpd now supports the upstream Linux kernel server-oriented
+  MPTCP_PM_CMD_SET_FLAGS generic netlink command through the new
+  mptcpd_pm_set_flags() function.  It allows the user to set MPTCP
+  flags for a specific local IP address.
+
+- An incorrect buffer size calculation when calling
+  mptcpd_pm_add_addr() when using an IPv6 addresses on platforms
+  running the upstream Linux kernel was fixed.
+
+- An "operation not supported" error that occurred when attempting to
+  retrieve MPTCP resource limits through the mptcpd_pm_get_limits()
+  function was fixed.
+
 - A network interface lookup problem in the "sspi" plugin was fixed.
+
+- Building mptcpd against ELL 0.39 is now supported.
 
 25 January 2021 - mptcpd 0.6
 

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@
 
 AC_PREREQ([2.69])
 AC_INIT([mptcpd],
-        [0.6],
+        [0.7],
         [mptcp@lists.linux.dev],
         [],
         [https://github.com/intel/mptcpd])

--- a/include/mptcpd/path_manager.h
+++ b/include/mptcpd/path_manager.h
@@ -208,19 +208,6 @@ MPTCPD_API int mptcpd_pm_set_limits(struct mptcpd_pm *pm,
                                     size_t len);
 
 /**
- * @brief Set MPTCP resource limits.
- *
- * @param[in] pm    The mptcpd path manager object.
- * @param[in] addr  Local IP address.
- * @param[in] flags Flags to be associated with @a addr.
- *
- * @return @c 0 if operation was successful. -1 or @c errno otherwise.
- */
-MPTCPD_API int mptcpd_pm_set_flags(struct mptcpd_pm *pm,
-                                   struct sockaddr const *addr,
-                                   mptcpd_flags_t flags);
-
-/**
  * @brief Get MPTCP resource limits.
  *
  * @param[in] pm       The mptcpd path manager object.
@@ -233,6 +220,20 @@ MPTCPD_API int mptcpd_pm_set_flags(struct mptcpd_pm *pm,
 MPTCPD_API int mptcpd_pm_get_limits(struct mptcpd_pm *pm,
                                     mptcpd_pm_get_limits_cb callback,
                                     void *data);
+
+/**
+ * @brief Set MPTCP flags for a local IP address.
+ *
+ * @param[in] pm    The mptcpd path manager object.
+ * @param[in] addr  Local IP address.
+ * @param[in] flags Flags to be associated with @a addr.
+ *
+ * @return @c 0 if operation was successful. -1 or @c errno otherwise.
+ */
+MPTCPD_API int mptcpd_pm_set_flags(struct mptcpd_pm *pm,
+                                   struct sockaddr const *addr,
+                                   mptcpd_flags_t flags);
+
 //@}
 
 /**


### PR DESCRIPTION
- MPTCP path management generic netlink events recently added to the
  upstream Linux kernel are now supported, and propagated to mptcpd
  plugins.  The same API is also found in the multipath-tcp.org
  kernel.  Differences between the two kernels are transparent to
  mptcpd plugins.

- Mptcpd now supports the upstream Linux kernel server-oriented
  MPTCP_PM_CMD_SET_FLAGS generic netlink command through the new
  mptcpd_pm_set_flags() function.  It allows the user to set MPTCP
  flags for a specific local IP address.

- An incorrect buffer size calculation when calling
  mptcpd_pm_add_addr() when using an IPv6 addresses on platforms
  running the upstream Linux kernel was corrected.

- An "operation not supported" error that occurred when attempting to
  retrieve MPTCP resource limits through the mptcpd_pm_get_limits()
  function was fixed.

- A network interface lookup problem in the "sspi" plugin was
  corrected.

- Building mptcpd against ELL 0.39 is now supported.