### PR TITLE
configure: add --disable-stack-protection option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -259,7 +259,7 @@ AX_APPEND_COMPILE_FLAGS([-Wextra -Werror -pedantic])
 AC_ARG_ENABLE(stack-protection,
 	[AS_HELP_STRING([--disable-stack-protection],
 		[Disable compiler stack protection.
-		FORTIFY_SOUCE=2 and -fstack-protector-strong]
+		FORTIFY_SOURCE=2 and -fstack-protector-strong]
 	)],
 	[],
 	[enable_stack_protection=yes])

--- a/configure.ac
+++ b/configure.ac
@@ -255,23 +255,36 @@ AX_APPEND_COMPILE_FLAGS([-Wextra -Werror -pedantic])
 # ---------------------------------------------------------------
 # Enable compile-time defense
 # ---------------------------------------------------------------
-# Fortify source
-# Enabling optimization implies _FORTIFY_SOURCE on some platforms.
-# Explicitly redefine to _FORTIFY_SOURCE=2 to make sure we have the
-# desired fortification level.
-AX_APPEND_FLAG([-U_FORTIFY_SOURCE], [CPPFLAGS])
-AX_APPEND_FLAG([-D_FORTIFY_SOURCE=2], [CPPFLAGS])
+
+AC_ARG_ENABLE(stack-protection,
+	[AS_HELP_STRING([--disable-stack-protection],
+		[Disable compiler stack protection.
+		FORTIFY_SOUCE=2 and -fstack-protector-strong]
+	)],
+	[],
+	[enable_stack_protection=yes])
+
+AS_IF([test "x$enable_stack_protection" = "xyes"],
+	[
+	# Fortify source
+	# Enabling optimization implies _FORTIFY_SOURCE on some platforms.
+	# Explicitly redefine to _FORTIFY_SOURCE=2 to make sure we have the
+	# desired fortification level.
+	AX_APPEND_FLAG([-U_FORTIFY_SOURCE], [CPPFLAGS])
+	AX_APPEND_FLAG([-D_FORTIFY_SOURCE=2], [CPPFLAGS])
+
+	# Stack-based buffer overrun detection
+	MPTCPD_ADD_COMPILE_FLAG([-fstack-protector-strong],
+	                        [# GCC < 4.9
+	                         MPTCPD_ADD_COMPILE_FLAG([-fstack-protector])
+	                        ])
+	],[]
+	)
 
 # Format string vulnerabilities
 # -Wformat=2 implies:
 #    -Wformat -Wformat-nonliteral -Wformat-security -Wformat-y2k
 AX_APPEND_COMPILE_FLAGS([-Wformat=2])
-
-# Stack-based buffer overrun detection
-MPTCPD_ADD_COMPILE_FLAG([-fstack-protector-strong],
-                        [# GCC < 4.9
-                         MPTCPD_ADD_COMPILE_FLAG([-fstack-protector])
-                        ])
 
 # Position Independent Execution (PIE)
 AX_APPEND_COMPILE_FLAGS([-fPIE], [EXECUTABLE_CFLAGS])


### PR DESCRIPTION
Enabling -DFORTIFY_SOURCE=* and -fstack-protector-* by default may
overwrite global (build) system settings, causing redefinition errors at
compile time.

Signed-off-by: Daniel Danzberger <daniel@dd-wrt.com>