### PR TITLE
src: Append port to add_addr command if given.

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -22,6 +22,29 @@
 #include "commands.h"
 
 
+uint16_t mptcpd_get_port_number(struct sockaddr const *addr)
+{
+        in_port_t port = 0;
+
+        if (addr == NULL)
+                return port;
+
+        if (addr->sa_family == AF_INET) {
+                struct sockaddr_in const *const addr4 =
+                        (struct sockaddr_in const*) addr;
+
+                port = addr4->sin_port;
+
+        } else if (addr->sa_family == AF_INET6) {
+                struct sockaddr_in6 const *const addr6 =
+                        (struct sockaddr_in6 const*) addr;
+
+                port = addr6->sin6_port;
+        }
+
+        return port;
+}
+
 bool mptcpd_check_genl_error(struct l_genl_msg *msg, char const *fname)
 {
         int const error = l_genl_msg_get_error(msg);

--- a/src/commands.h
+++ b/src/commands.h
@@ -108,6 +108,18 @@ inline uint16_t mptcpd_get_addr_family(struct sockaddr const *addr)
 }
 
 /**
+ * @brief Get IP port number.
+ *
+ * @param[in] addr Network address information.
+ *
+ * Get IP port suitably typed for use in MPTCP generic netlink API
+ * calls, or zero if no address was provided.
+ *
+ * @return IP port number, or zero if no IP address was provided.
+ */
+uint16_t mptcpd_get_port_number(struct sockaddr const *addr);
+
+/**
  * @brief Get upstream kernel MPTCP generic netlink command
  *        operations.
  */

--- a/src/netlink_pm_mptcp_org.c
+++ b/src/netlink_pm_mptcp_org.c
@@ -95,29 +95,6 @@ static void check_kernel_mptcp_path_manager(void)
         }
 }
 
-static uint16_t get_port_number(struct sockaddr const *addr)
-{
-        in_port_t port = 0;
-
-        if (addr == NULL)
-                return port;
-
-        if (addr->sa_family == AF_INET) {
-                struct sockaddr_in const *const addr4 =
-                        (struct sockaddr_in const*) addr;
-
-                port = addr4->sin_port;
-
-        } else if (addr->sa_family == AF_INET6) {
-                struct sockaddr_in6 const *const addr6 =
-                        (struct sockaddr_in6 const*) addr;
-
-                port = addr6->sin6_port;
-        }
-
-        return port;
-}
-
 static bool append_addr_attr(struct l_genl_msg *msg,
                              struct sockaddr const *addr,
                              bool local)
@@ -189,7 +166,7 @@ static int mptcp_org_add_addr(struct mptcpd_pm *pm,
 
         // Types chosen to match MPTCP genl API.
         uint16_t const family = mptcpd_get_addr_family(addr);
-        uint16_t const port   = get_port_number(addr);
+        uint16_t const port   = mptcpd_get_port_number(addr);
 
         /**
          * @todo Verify that this payload size calculation is
@@ -314,8 +291,8 @@ static int mptcp_org_add_subflow(struct mptcpd_pm *pm,
          */
 
         uint16_t const family      = mptcpd_get_addr_family(remote_addr);
-        uint16_t const local_port  = get_port_number(local_addr);
-        uint16_t const remote_port = get_port_number(remote_addr);
+        uint16_t const local_port  = mptcpd_get_port_number(local_addr);
+        uint16_t const remote_port = mptcpd_get_port_number(remote_addr);
         // uint16_t per MPTCP genl API.
 
         if (remote_port == 0)
@@ -410,8 +387,8 @@ static int mptcp_org_set_backup(struct mptcpd_pm *pm,
          */
 
         uint16_t const family      = mptcpd_get_addr_family(local_addr);
-        uint16_t const local_port  = get_port_number(local_addr);
-        uint16_t const remote_port = get_port_number(remote_addr);
+        uint16_t const local_port  = mptcpd_get_port_number(local_addr);
+        uint16_t const remote_port = mptcpd_get_port_number(remote_addr);
         // uint16_t per MPTCP genl API.
 
         /**
@@ -493,8 +470,8 @@ static int mptcp_org_remove_subflow(struct mptcpd_pm *pm,
          */
 
         uint16_t const family      = mptcpd_get_addr_family(local_addr);
-        uint16_t const local_port  = get_port_number(local_addr);
-        uint16_t const remote_port = get_port_number(remote_addr);
+        uint16_t const local_port  = mptcpd_get_port_number(local_addr);
+        uint16_t const remote_port = mptcpd_get_port_number(remote_addr);
         // uint16_t per MPTCP genl API.
 
         /**

--- a/src/netlink_pm_upstream.c
+++ b/src/netlink_pm_upstream.c
@@ -367,7 +367,7 @@ static int upstream_add_addr(struct mptcpd_pm *pm,
 
         // Types chosen to match MPTCP genl API.
         uint16_t const family = mptcpd_get_addr_family(addr);
-        uint16_t const port   = get_port_number(addr);
+        uint16_t const port   = mptcpd_get_port_number(addr);
 
         /*
           The MPTCP_PM_ADDR_FLAG_SIGNAL flag is required when a port

--- a/src/netlink_pm_upstream.c
+++ b/src/netlink_pm_upstream.c
@@ -359,6 +359,7 @@ static int upstream_add_addr(struct mptcpd_pm *pm,
           Payload (nested):
               Local address family
               Local address
+              Local port (optional)
               Local address ID (optional)
               Flags (optional)
               Network inteface index (optional)
@@ -366,10 +367,19 @@ static int upstream_add_addr(struct mptcpd_pm *pm,
 
         // Types chosen to match MPTCP genl API.
         uint16_t const family = mptcpd_get_addr_family(addr);
+        uint16_t const port   = get_port_number(addr);
+
+        /*
+          The MPTCP_PM_ADDR_FLAG_SIGNAL flag is required when a port
+          is specified.  Make sure it is set.
+        */
+        if (port != 0)
+                flags |= MPTCP_PM_ADDR_FLAG_SIGNAL;
 
         size_t const payload_size =
                 MPTCPD_NLA_ALIGN(family)
                 + MPTCPD_NLA_ALIGN_ADDR(addr)
+                + MPTCPD_NLA_ALIGN_OPT(port)
                 + MPTCPD_NLA_ALIGN_OPT(address_id)
                 + MPTCPD_NLA_ALIGN_OPT(flags)
                 + MPTCPD_NLA_ALIGN_OPT(index);
@@ -386,6 +396,11 @@ static int upstream_add_addr(struct mptcpd_pm *pm,
                         sizeof(family),  // sizeof(uint16_t)
                         &family)
                 && append_addr_attr(msg, addr)
+                && (port == 0 ||
+                    l_genl_msg_append_attr(msg,
+                                           MPTCP_PM_ADDR_ATTR_PORT,
+                                           sizeof(port),  // sizeof(uint16_t)
+                                           &port))
                 && (address_id == 0
                     || l_genl_msg_append_attr(
                             msg,


### PR DESCRIPTION
A port may be specified as an attribute of the upstream kernel
`MPTCP_PM_CMD_ADD_ADDR` command.  Append it to generic netlink message
accordingly.  Make sure the `MPTCP_PM_ADDR_FLAG_SIGNAL` flag is also set
since the kernel won't use the port without it.