### PR TITLE
Install automated build deps non-interactively.

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: dependencies
-      run: sudo apt install autoconf-archive libell-dev pandoc
+      run: sudo apt-get -y install autoconf-archive libell-dev pandoc
     - name: bootstrap
       run: ./bootstrap
     - name: configure


### PR DESCRIPTION
Make sure all package dependencies are installed non-interactively.
Also, use apt-get instead of apt since the apt command line interface
is not stable.