### PR TITLE
Fix build regression against ELL 0.33.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -244,6 +244,12 @@ AC_SEARCH_LIBS(
     [],
     [AC_MSG_ERROR([library with dlopen() could not be found])])
 
+dnl l_hashmap_replace() was introduced in ELL v0.33.
+AC_CHECK_FUNC([l_hashmap_replace],
+              [AC_DEFINE([HAVE_L_HASHMAP_REPLACE],
+	                 [],
+			 [ELL has l_hashmap_replace()])])
+
 # ---------------------------------------------------------------
 # Enable additional C compiler warnings.  We do this after all
 # Autoconf tests have been run since not all autoconf macros are

--- a/lib/id_manager.c
+++ b/lib/id_manager.c
@@ -161,6 +161,25 @@ static void *mptcpd_hashmap_key_copy(void const *p)
 
 // ----------------------------------------------------------------------
 
+static bool mptcpd_hashmap_replace(struct l_hashmap *map,
+                                   void const *key,
+                                   void *value,
+                                   void **old_value)
+{
+#ifdef HAVE_L_HASHMAP_REPLACE
+        return l_hashmap_replace(map, key, value, old_value);
+#else
+        void *const old = l_hashmap_remove(map, key);
+
+        if (old_value != NULL)
+                *old_value = old;
+
+        return l_hashmap_insert(map, key, value);
+#endif
+}
+
+// ----------------------------------------------------------------------
+
 struct mptcpd_idm *mptcpd_idm_create(void)
 {
         struct mptcpd_idm *idm = l_new(struct mptcpd_idm, 1);
@@ -209,7 +228,10 @@ bool mptcpd_idm_map_id(struct mptcpd_idm *idm,
             || !l_uintset_put(idm->ids, id))
                 return false;
 
-        if (!l_hashmap_replace(idm->map, sa, L_UINT_TO_PTR(id), NULL)) {
+        if (!mptcpd_hashmap_replace(idm->map,
+                                    sa,
+                                    L_UINT_TO_PTR(id),
+                                    NULL)) {
                 (void) l_uintset_take(idm->ids, id);
 
                 return false;


### PR DESCRIPTION
The mptcpd ID manager uses the ELL `l_hashmap_replace()` function, but that function was introduced in ELL 0.33.  Implement the `l_hashmap_replace()` functionality in mptcpd through calls to `l_hashmap_remove()` and `l_hashmap_insert()` when `l_hashmap_replace()` is not available.
