### PR TITLE
Fix build regression against ELL 0.31.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -244,6 +244,8 @@ AC_SEARCH_LIBS(
     [],
     [AC_MSG_ERROR([library with dlopen() could not be found])])
 
+mptcpd_save_libs=$LIBS
+LIBS="$LIBS $ELL_LIBS"
 dnl l_genl_msg_get_extended_error() was introduced in ELL v0.31.
 AC_CHECK_FUNC([l_genl_msg_get_extended_error],
               [AC_DEFINE([HAVE_L_GENL_MSG_GET_EXTENDED_ERROR],
@@ -255,6 +257,7 @@ AC_CHECK_FUNC([l_hashmap_replace],
               [AC_DEFINE([HAVE_L_HASHMAP_REPLACE],
 	                 [],
 			 [ELL has l_hashmap_replace()])])
+LIBS=$mptcpd_save_libs
 
 # ---------------------------------------------------------------
 # Enable additional C compiler warnings.  We do this after all

--- a/configure.ac
+++ b/configure.ac
@@ -244,6 +244,12 @@ AC_SEARCH_LIBS(
     [],
     [AC_MSG_ERROR([library with dlopen() could not be found])])
 
+dnl l_genl_msg_get_extended_error() was introduced in ELL v0.31.
+AC_CHECK_FUNC([l_genl_msg_get_extended_error],
+              [AC_DEFINE([HAVE_L_GENL_MSG_GET_EXTENDED_ERROR],
+	                 [],
+			 [ELL has l_genl_msg_get_extended_error()])])
+
 dnl l_hashmap_replace() was introduced in ELL v0.33.
 AC_CHECK_FUNC([l_hashmap_replace],
               [AC_DEFINE([HAVE_L_HASHMAP_REPLACE],

--- a/configure.ac
+++ b/configure.ac
@@ -244,6 +244,12 @@ AC_SEARCH_LIBS(
     [],
     [AC_MSG_ERROR([library with dlopen() could not be found])])
 
+dnl l_hashmap_replace() was introduced in ELL v0.33.
+AC_CHECK_FUNC([l_hashmap_replace],
+              [AC_DEFINE([HAVE_L_HASHMAP_REPLACE],
+	                 [],
+			 [ELL has l_hashmap_replace()])])
+
 # ---------------------------------------------------------------
 # Enable additional C compiler warnings.  We do this after all
 # Autoconf tests have been run since not all autoconf macros are

--- a/lib/id_manager.c
+++ b/lib/id_manager.c
@@ -161,6 +161,25 @@ static void *mptcpd_hashmap_key_copy(void const *p)
 
 // ----------------------------------------------------------------------
 
+static bool mptcpd_hashmap_replace(struct l_hashmap *map,
+                                   void const *key,
+                                   void *value,
+                                   void **old_value)
+{
+#ifdef HAVE_L_HASHMAP_REPLACE
+        return l_hashmap_replace(map, key, value, old_value);
+#else
+        void *const old = l_hashmap_remove(map, key);
+
+        if (old_value != NULL)
+                *old_value = old;
+
+        return l_hashmap_insert(map, key, value);
+#endif
+}
+
+// ----------------------------------------------------------------------
+
 struct mptcpd_idm *mptcpd_idm_create(void)
 {
         struct mptcpd_idm *idm = l_new(struct mptcpd_idm, 1);
@@ -209,7 +228,10 @@ bool mptcpd_idm_map_id(struct mptcpd_idm *idm,
             || !l_uintset_put(idm->ids, id))
                 return false;
 
-        if (!l_hashmap_replace(idm->map, sa, L_UINT_TO_PTR(id), NULL)) {
+        if (!mptcpd_hashmap_replace(idm->map,
+                                    sa,
+                                    L_UINT_TO_PTR(id),
+                                    NULL)) {
                 (void) l_uintset_take(idm->ids, id);
 
                 return false;

--- a/src/commands.c
+++ b/src/commands.c
@@ -30,7 +30,11 @@ bool mptcpd_check_genl_error(struct l_genl_msg *msg, char const *fname)
                 // Error during send.  Likely insufficient perms.
 
                 char const *const genl_errmsg =
+#ifdef HAVE_L_GENL_MSG_GET_EXTENDED_ERROR
                         l_genl_msg_get_extended_error(msg);
+#else
+                        NULL;
+#endif
 
                 if (genl_errmsg != NULL) {
                         l_error("%s: %s", fname, genl_errmsg);


### PR DESCRIPTION
Work around missing ELL functions used by mptcpd that were introduced in ELL 0.31+.

Check if the `l_genl_msg_get_extended_error()` function is available.   It was introduced in ELL 0.31.  Set the extended error message to `NULL`  if the function is not available.

The mptcpd ID manager uses the ELL `l_hashmap_replace()` function, but that function was introduced in ELL 0.33.  Implement the `l_hashmap_replace()` functionality in mptcpd through calls to `l_hashmap_remove()` and `l_hashmap_insert()` when `l_hashmap_replace()` is not available.
