### PR TITLE
cccp.yml: Expect tests to fail on Ubuntu 20.04.

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -22,8 +22,9 @@ jobs:
     - name: make
       run: make
     - name: make check
-      run: make check
+      # The kernel in Ubuntu 20.04 doesn't support MPTCP.  Expect failures.
+      run: make check XFAIL_TESTS="test-commands test-path-manager test-start-stop"
     - name: make distcheck
-      run: make distcheck
+      run: make distcheck XFAIL_TESTS="test-commands test-path-manager test-start-stop"
     - name: make installcheck
       run: sudo make installcheck


### PR DESCRIPTION
The Linux kernel in Ubuntu 20.04 doesn't support MPTCP, which causes
some mptcpd tests to fail.  Explicitly declare those as tests expected
to fail through the XFAIL_TESTS make variable when running `make
check' and `make distcheck'.  This addresses the GitHub Action build
workflow on Ubuntu 20.04.