### PR TITLE
Require remote address for subflow creation.

### DIFF
--- a/include/linux/mptcp_org.h
+++ b/include/linux/mptcp_org.h
@@ -87,8 +87,8 @@ enum {
  *   - MPTCP_CMD_REMOVE: token, loc_id
  *       Announce that an address has been lost to the peer.
  *
- *   - MPTCP_CMD_SUB_CREATE: token, family, loc_id, rem_id, [saddr4 | saddr6,
- *                           daddr4 | daddr6, dport [, sport, backup, if_idx]]
+ *   - MPTCP_CMD_SUB_CREATE: token, family, loc_id, rem_id, daddr4 | daddr6,
+ *                           dport [,saddr4 | saddr6, sport, backup, if_idx]
  *       Create a new subflow.
  *
  *   - MPTCP_CMD_SUB_DESTROY: token, family, saddr4 | saddr6, daddr4 | daddr6,

--- a/include/mptcpd/path_manager.h
+++ b/include/mptcpd/path_manager.h
@@ -252,6 +252,8 @@ MPTCPD_API int mptcpd_pm_set_flags(struct mptcpd_pm *pm,
  * @param[in] remote_address_id MPTCP remote address ID.
  * @param[in] local_addr        MPTCP subflow local address
  *                              information, including the port.
+ *                              This argument is optional and may be
+ *                              @c NULL.
  * @param[in] remote_addr       MPTCP subflow remote address
  *                              information, including the port.
  * @param[in] backup            Whether or not to set the MPTCP

--- a/lib/path_manager.c
+++ b/lib/path_manager.c
@@ -241,7 +241,7 @@ int mptcpd_pm_add_subflow(struct mptcpd_pm *pm,
                           struct sockaddr const *remote_addr,
                           bool backup)
 {
-        if (pm == NULL)
+        if (pm == NULL || remote_addr == NULL)
                 return EINVAL;
 
         if (!is_pm_ready(pm, __func__))


### PR DESCRIPTION
The remote address and port are required when creating a subflow.  Update the `mptcpd_pm_add_subflow()` implementation accordingly.

Fixes #134.