### PR TITLE
mptcpize: Fix gcc static analyzer diagnostic.

### DIFF
--- a/src/mptcpize.c
+++ b/src/mptcpize.c
@@ -135,7 +135,6 @@ static char *locate_unit(const char *name)
 	while ((read = getline(&line, &len, systemctl)) != -1) {
 		if (strncmp(line, SYSTEMD_UNIT_VAR, strlen(SYSTEMD_UNIT_VAR)) == 0) {
 			char *ret = strdup(&line[strlen(SYSTEMD_UNIT_VAR)]);
-
 			if (!ret)
 				error(1, errno, "failed to duplicate string");
 

--- a/src/mptcpize.c
+++ b/src/mptcpize.c
@@ -136,6 +136,9 @@ static char *locate_unit(const char *name)
 		if (strncmp(line, SYSTEMD_UNIT_VAR, strlen(SYSTEMD_UNIT_VAR)) == 0) {
 			char *ret = strdup(&line[strlen(SYSTEMD_UNIT_VAR)]);
 
+			if (!ret)
+				error(1, errno, "failed to duplicate string");
+
 			// trim trailing newline, if any
 			len = strlen(ret);
 			if (len > 0 && ret[len - 1] == '\n')


### PR DESCRIPTION
The gcc 11.1 static analyzer flagged a potential NULL argument passed
to a strlen() call.  Check for NULL prior to calling strlen().