### PR TITLE
src: Fix configuration order issues.

### DIFF
--- a/src/configuration.c
+++ b/src/configuration.c
@@ -321,9 +321,8 @@ static void parse_config_plugin_dir(struct mptcpd_config *config,
                                       group,
                                       "plugin-dir");
 
-        set_plugin_dir(config,
-                       plugin_dir ? plugin_dir :
-                       l_strdup(MPTCPD_DEFAULT_PLUGINDIR));
+        if (plugin_dir != NULL)
+                set_plugin_dir(config, plugin_dir);
 }
 
 static void parse_config_default_plugin(struct mptcpd_config *config,

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -516,8 +516,9 @@ struct mptcpd_config *mptcpd_config_create(int argc, char *argv[])
         l_debug("path manager plugin directory: %s",
                 config->plugin_dir);
 
-        l_debug("default path manager plugin: %s",
-                config->default_plugin);
+        if (config->default_plugin != NULL)
+                l_debug("default path manager plugin: %s",
+                        config->default_plugin);
 
         return config;
 }


### PR DESCRIPTION
Overriding a given system configuration (e.g. /etc/mptcpd.conf) value
through the corresponding command line option could fail if the system
configuration parse fails.  Parse the command line options before the
system configuration to prevent such a problem from occurring.