### PR TITLE
ccpp.yml: Remove tests that pass from XFAIL list.

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -23,9 +23,9 @@ jobs:
       run: make
     - name: make check
       # The kernel in Ubuntu 20.04 doesn't support MPTCP.  Expect failures.
-      run: make check XFAIL_TESTS="test-commands test-path-manager test-start-stop"
+      run: make check XFAIL_TESTS="test-commands"
     - name: make distcheck
-      run: make distcheck XFAIL_TESTS="test-commands test-path-manager test-start-stop"
+      run: make distcheck XFAIL_TESTS="test-commands"
     - name: make install
       run: sudo make install
     - name: make installcheck


### PR DESCRIPTION
Some tests that were listed as expected to fail through the Automake `XFAIL_TESTS` variable now pass, triggering an unexpected pass "`XPASS`" test suite failure.  Remove the tests that now pass from `XFAIL_TESTS`.