### PR TITLE
Split in-kernel PM add_addr/remove_addr commands.

### DIFF
--- a/include/mptcpd/path_manager.h
+++ b/include/mptcpd/path_manager.h
@@ -113,10 +113,7 @@ MPTCPD_API bool mptcpd_pm_ready(struct mptcpd_pm const *pm);
  *                  option.  The port is optional, and is
  *                  ignored if it is zero.
  * @param[in] id    MPTCP local address ID.
- * @param[in] token MPTCP connection token..
- *
- * @todo Should we define corresponding mptcpd flags instead of
- *       exposing the flags in <linux/mptcp.h>?
+ * @param[in] token MPTCP connection token.
  *
  * @return @c 0 if operation was successful. @c errno otherwise.
  */
@@ -228,21 +225,18 @@ MPTCPD_API int mptcpd_pm_remove_subflow(
  *                  ignored if it is zero.
  * @param[in] id    MPTCP local address ID.
  * @param[in] flags Bitset of MPTCP flags associated with the network
- *                  address, e.g. @c MPTCP_PM_ADDR_FLAG_BACKUP @c |
- *                   @c MPTCP_PM_ADDR_FLAG_SUBFLOW.  Optional for
+ *                  address, e.g. @c MPTCPD_ADDR_FLAG_SUBFLOW @c |
+ *                   @c MPTCPD_ADDR_FLAG_BACKUP.  Optional for
  *                  upstream kernel (e.g. set to zero).
  * @param[in] index Network interface index.  Optional for upstream
  *                  Linux kernel (e.g. set to zero).
- *
- * @todo Should we define corresponding mptcpd flags instead of
- *       exposing the flags in <linux/mptcp.h>?
  *
  * @return @c 0 if operation was successful. @c errno otherwise.
  */
 MPTCPD_API int mptcpd_kpm_add_addr(struct mptcpd_pm *pm,
                                    struct sockaddr const *addr,
                                    mptcpd_aid_t id,
-                                   uint32_t flags,
+                                   mptcpd_flags_t flags,
                                    int index);
 
 /**

--- a/include/mptcpd/path_manager.h
+++ b/include/mptcpd/path_manager.h
@@ -33,7 +33,7 @@ struct mptcpd_addr_info;
  *       running, e.g. through the ELL @c l_main_run() function.
  *       Users only need to be concerned about this if they are
  *       explicitly creating a @c struct @c mptcpd_pm instance instead
- *       of relying on mptcpd to do so, such what is done in some
+ *       of relying on mptcpd to do so, such as what is done in some
  *       mptcpd unit tests.
  */
 struct mptcpd_pm_ops
@@ -98,6 +98,13 @@ MPTCPD_API bool mptcpd_pm_register_ops(struct mptcpd_pm *pm,
 MPTCPD_API bool mptcpd_pm_ready(struct mptcpd_pm const *pm);
 
 /**
+ * @name Client-oriented Path Management Commands
+ *
+ * Client-oriented path management commands that allow for
+ * per-connection path management.
+ */
+///@{
+/**
  * @brief Advertise new network address to peers.
  *
  * @param[in] pm    The mptcpd path manager object.
@@ -106,15 +113,7 @@ MPTCPD_API bool mptcpd_pm_ready(struct mptcpd_pm const *pm);
  *                  option.  The port is optional, and is
  *                  ignored if it is zero.
  * @param[in] id    MPTCP local address ID.
- * @param[in] flags Bitset of MPTCP flags associated with the network
- *                  address, e.g. @c MPTCP_PM_ADDR_FLAG_BACKUP @c |
- *                   @c MPTCP_PM_ADDR_FLAG_SUBFLOW.  Optional for
- *                  upstream kernel.  Unused by the multipath-tcp.org
- *                  Linux kernel (e.g. set to zero).
- * @param[in] index Network interface index.  Optional for upstream
- *                  Linux kernel (e.g. set to zero).
- * @param[in] token MPTCP connection token.  Unused by the upstream
- *                  Linux kernel (e.g. set to zero).
+ * @param[in] token MPTCP connection token..
  *
  * @todo Should we define corresponding mptcpd flags instead of
  *       exposing the flags in <linux/mptcp.h>?
@@ -124,8 +123,6 @@ MPTCPD_API bool mptcpd_pm_ready(struct mptcpd_pm const *pm);
 MPTCPD_API int mptcpd_pm_add_addr(struct mptcpd_pm *pm,
                                   struct sockaddr const *addr,
                                   mptcpd_aid_t id,
-                                  uint32_t flags,
-                                  int index,
                                   mptcpd_token_t token);
 
 /**
@@ -144,105 +141,6 @@ MPTCPD_API int mptcpd_pm_remove_addr(struct mptcpd_pm *pm,
                                      mptcpd_aid_t address_id,
                                      mptcpd_token_t token);
 
-/**
- * @name Server-oriented Path Management Commands
- *
- * Server-oriented path management commands supported by the upstream
- * Linux kernel.  Path management is handled by the kernel.
- */
-///@{
-/**
- * @brief Get network address corresponding to an address ID.
- *
- * @param[in] pm       The mptcpd path manager object.
- * @param[in] id       MPTCP local address ID.
- * @param[in] callback Function to be called when the network address
- *                     corresponding to the given MPTCP address @a id
- *                     has been retrieved.
- * @param[in] data     Data to be passed to the @a callback function.
- *
- * @return @c 0 if operation was successful. -1 or @c errno otherwise.
- */
-MPTCPD_API int mptcpd_pm_get_addr(struct mptcpd_pm *pm,
-                                  mptcpd_aid_t id,
-                                  mptcpd_pm_get_addr_cb callback,
-                                  void *data);
-
-/**
- * @brief Get list (array) of MPTCP network addresses.
- *
- * @param[in] pm       The mptcpd path manager object.
- * @param[in] callback Function to be called when a network address
- *                     has been retrieved.  This function will be
- *                     called once per dumped network address.
- * @param[in] data     Data to be passed to the @a callback function.
- *
- * @return @c 0 if operation was successful. -1 or @c errno otherwise.
- */
-MPTCPD_API int mptcpd_pm_dump_addrs(struct mptcpd_pm *pm,
-                                    mptcpd_pm_get_addr_cb callback,
-                                    void *data);
-
-/**
- * @brief Flush MPTCP addresses.
- *
- * @param[in] pm The mptcpd path manager object.
- *
- * @todo Improve documentation.
- *
- * @return @c 0 if operation was successful. -1 or @c errno otherwise.
- */
-MPTCPD_API int mptcpd_pm_flush_addrs(struct mptcpd_pm *pm);
-
-/**
- * @brief Set MPTCP resource limits.
- *
- * @param[in] pm     The mptcpd path manager object.
- * @param[in] limits Array of MPTCP resource type/limit pairs.
- * @param[in] len    Length of the @a limits array.
- *
- * @return @c 0 if operation was successful. -1 or @c errno otherwise.
- */
-MPTCPD_API int mptcpd_pm_set_limits(struct mptcpd_pm *pm,
-                                    struct mptcpd_limit const *limits,
-                                    size_t len);
-
-/**
- * @brief Get MPTCP resource limits.
- *
- * @param[in] pm       The mptcpd path manager object.
- * @param[in] callback Function to be called when the MPTCP resource
- *                     limits have been retrieved.
- * @param[in] data     Data to be passed to the @a callback function.
- *
- * @return @c 0 if operation was successful. -1 or @c errno otherwise.
- */
-MPTCPD_API int mptcpd_pm_get_limits(struct mptcpd_pm *pm,
-                                    mptcpd_pm_get_limits_cb callback,
-                                    void *data);
-
-/**
- * @brief Set MPTCP flags for a local IP address.
- *
- * @param[in] pm    The mptcpd path manager object.
- * @param[in] addr  Local IP address.
- * @param[in] flags Flags to be associated with @a addr.
- *
- * @return @c 0 if operation was successful. -1 or @c errno otherwise.
- */
-MPTCPD_API int mptcpd_pm_set_flags(struct mptcpd_pm *pm,
-                                   struct sockaddr const *addr,
-                                   mptcpd_flags_t flags);
-
-///@}
-
-/**
- * @name Client-oriented Path Management Commands
- *
- * Client-oriented path management commands that allow for
- * per-connection path management.
- */
-///@{
 /**
  * @brief Create a new subflow.
  *
@@ -310,6 +208,140 @@ MPTCPD_API int mptcpd_pm_remove_subflow(
         mptcpd_token_t token,
         struct sockaddr const *local_addr,
         struct sockaddr const *remote_addr);
+///@}
+
+/**
+ * @name Server-oriented Path Management Commands
+ *
+ * Server-oriented path management commands supported by the upstream
+ * Linux kernel.  Path management is handled by the in-kernel path
+ * manager.
+ */
+///@{
+/**
+ * @brief Advertise new network address to peers.
+ *
+ * @param[in] pm    The mptcpd path manager object.
+ * @param[in] addr  Local IP address and port to be advertised
+ *                  through the MPTCP protocol @c ADD_ADDR
+ *                  option.  The port is optional, and is
+ *                  ignored if it is zero.
+ * @param[in] id    MPTCP local address ID.
+ * @param[in] flags Bitset of MPTCP flags associated with the network
+ *                  address, e.g. @c MPTCP_PM_ADDR_FLAG_BACKUP @c |
+ *                   @c MPTCP_PM_ADDR_FLAG_SUBFLOW.  Optional for
+ *                  upstream kernel (e.g. set to zero).
+ * @param[in] index Network interface index.  Optional for upstream
+ *                  Linux kernel (e.g. set to zero).
+ *
+ * @todo Should we define corresponding mptcpd flags instead of
+ *       exposing the flags in <linux/mptcp.h>?
+ *
+ * @return @c 0 if operation was successful. @c errno otherwise.
+ */
+MPTCPD_API int mptcpd_kpm_add_addr(struct mptcpd_pm *pm,
+                                   struct sockaddr const *addr,
+                                   mptcpd_aid_t id,
+                                   uint32_t flags,
+                                   int index);
+
+/**
+ * @brief Stop advertising network address to peers.
+ *
+ * @param[in] pm         The mptcpd path manager object.
+ * @param[in] address_id MPTCP local address ID to be sent in the
+ *                       MPTCP protocol @c REMOVE_ADDR option
+ *                       corresponding to the local address that will
+ *                       no longer be available.
+ *
+ * @return @c 0 if operation was successful. -1 or @c errno otherwise.
+ */
+MPTCPD_API int mptcpd_kpm_remove_addr(struct mptcpd_pm *pm,
+                                      mptcpd_aid_t address_id);
+
+/**
+ * @brief Get network address corresponding to an address ID.
+ *
+ * @param[in] pm       The mptcpd path manager object.
+ * @param[in] id       MPTCP local address ID.
+ * @param[in] callback Function to be called when the network address
+ *                     corresponding to the given MPTCP address @a id
+ *                     has been retrieved.
+ * @param[in] data     Data to be passed to the @a callback function.
+ *
+ * @return @c 0 if operation was successful. -1 or @c errno otherwise.
+ */
+MPTCPD_API int mptcpd_kpm_get_addr(struct mptcpd_pm *pm,
+                                   mptcpd_aid_t id,
+                                   mptcpd_pm_get_addr_cb callback,
+                                   void *data);
+
+/**
+ * @brief Get list (array) of MPTCP network addresses.
+ *
+ * @param[in] pm       The mptcpd path manager object.
+ * @param[in] callback Function to be called when a network address
+ *                     has been retrieved.  This function will be
+ *                     called once per dumped network address.
+ * @param[in] data     Data to be passed to the @a callback function.
+ *
+ * @return @c 0 if operation was successful. -1 or @c errno otherwise.
+ */
+MPTCPD_API int mptcpd_kpm_dump_addrs(struct mptcpd_pm *pm,
+                                     mptcpd_pm_get_addr_cb callback,
+                                     void *data);
+
+/**
+ * @brief Flush MPTCP addresses.
+ *
+ * @param[in] pm The mptcpd path manager object.
+ *
+ * @todo Improve documentation.
+ *
+ * @return @c 0 if operation was successful. -1 or @c errno otherwise.
+ */
+MPTCPD_API int mptcpd_kpm_flush_addrs(struct mptcpd_pm *pm);
+
+/**
+ * @brief Set MPTCP resource limits.
+ *
+ * @param[in] pm     The mptcpd path manager object.
+ * @param[in] limits Array of MPTCP resource type/limit pairs.
+ * @param[in] len    Length of the @a limits array.
+ *
+ * @return @c 0 if operation was successful. -1 or @c errno otherwise.
+ */
+MPTCPD_API int mptcpd_kpm_set_limits(struct mptcpd_pm *pm,
+                                     struct mptcpd_limit const *limits,
+                                     size_t len);
+
+/**
+ * @brief Get MPTCP resource limits.
+ *
+ * @param[in] pm       The mptcpd path manager object.
+ * @param[in] callback Function to be called when the MPTCP resource
+ *                     limits have been retrieved.
+ * @param[in] data     Data to be passed to the @a callback function.
+ *
+ * @return @c 0 if operation was successful. -1 or @c errno otherwise.
+ */
+MPTCPD_API int mptcpd_kpm_get_limits(struct mptcpd_pm *pm,
+                                     mptcpd_pm_get_limits_cb callback,
+                                     void *data);
+
+/**
+ * @brief Set MPTCP flags for a local IP address.
+ *
+ * @param[in] pm    The mptcpd path manager object.
+ * @param[in] addr  Local IP address.
+ * @param[in] flags Flags to be associated with @a addr.
+ *
+ * @return @c 0 if operation was successful. -1 or @c errno otherwise.
+ */
+MPTCPD_API int mptcpd_kpm_set_flags(struct mptcpd_pm *pm,
+                                    struct sockaddr const *addr,
+                                    mptcpd_flags_t flags);
+
 ///@}
 
 /**

--- a/include/mptcpd/private/netlink_pm.h
+++ b/include/mptcpd/private/netlink_pm.h
@@ -31,6 +31,15 @@ struct mptcpd_netlink_pm
 
         /// MPTCP path management generic netlink command functions.
         struct mptcpd_pm_cmd_ops const *const cmd_ops;
+
+        /**
+         * @brief In-kernel MPTCP path management generic netlink command
+         *        functions.
+         *
+         * Generic netlink command functions specific to the in-kernel
+         * path manager.
+         */
+        struct mptcpd_kpm_cmd_ops const *const kcmd_ops;
 };
 
 

--- a/include/mptcpd/private/path_manager.h
+++ b/include/mptcpd/private/path_manager.h
@@ -343,6 +343,9 @@ struct mptcpd_kpm_cmd_ops
          * @param[in] pm    The mptcpd path manager object.
          * @param[in] addr  Local IP address information.
          * @param[in] flags Flags to be associated with @a addr.
+         *
+         * @return @c 0 if operation was successful. -1 or @c errno
+         *         otherwise.
          */
         int (*set_flags)(struct mptcpd_pm *pm,
                          struct sockaddr const *addr,

--- a/include/mptcpd/private/path_manager.h
+++ b/include/mptcpd/private/path_manager.h
@@ -338,7 +338,7 @@ struct mptcpd_kpm_cmd_ops
                           void *data);
 
         /**
-         * @brief
+         * @brief Set MPTCP flags for a local IP address.
          *
          * @param[in] pm    The mptcpd path manager object.
          * @param[in] addr  Local IP address information.

--- a/include/mptcpd/private/path_manager.h
+++ b/include/mptcpd/private/path_manager.h
@@ -125,17 +125,6 @@ struct mptcpd_pm_cmd_ops
          * @privatesection
          */
         /**
-         * @name Common Path Management Commands
-         *
-         * Path management common to both the upstream and
-         * multipath-tcp.org Linux kernels.
-         *
-         * @todo Consider splitting these commands into
-         *       server-oriented and client-oriented cases.  There
-         *       shouldn't be any overlap between these use cases.
-         */
-        ///@{
-        /**
          * @brief Advertise new network address to peers.
          *
          * @param[in] pm    The mptcpd path manager object.
@@ -157,113 +146,7 @@ struct mptcpd_pm_cmd_ops
         int (*remove_addr)(struct mptcpd_pm *pm,
                            mptcpd_aid_t address_id,
                            mptcpd_token_t token);
-        ///@}
 
-        /**
-         * @name Server-oriented Path Management Commands
-         *
-         * Server-oriented path management commands supported by the
-         * upstream Linux kernel.  Path management is handled by the
-         * kernel.
-         */
-        ///@{
-        /**
-         * @brief Get network address corresponding to an address ID.
-         *
-         * @param[in] pm       The mptcpd path manager object.
-         * @param[in] id       MPTCP local address ID.
-         * @param[in] callback Function to be called when the network
-         *                     address corresponding to the given
-         *                     MPTCP address @a id has been
-         *                     retrieved.
-         * @param[in] data     Data to be passed to the @a callback
-         *                     function.
-         *
-         * @return @c 0 if operation was successful. -1 or @c errno
-         *         otherwise.
-         */
-        int (*get_addr)(struct mptcpd_pm *pm,
-                        mptcpd_aid_t id,
-                        mptcpd_pm_get_addr_cb callback,
-                        void *data);
-
-        /**
-         * @brief Dump list of network addresses.
-         *
-         * @param[in] pm       The mptcpd path manager object.
-         * @param[in] callback Function to be called when a dump of
-         *                     network addresses has been retrieved.
-         * @param[in] data     Data to be passed to the @a callback
-         *                     function.
-         *
-         * @return @c 0 if operation was successful. -1 or @c errno
-         *         otherwise.
-         */
-        int (*dump_addrs)(struct mptcpd_pm *pm,
-                          mptcpd_pm_get_addr_cb callback,
-                          void *data);
-
-        /**
-         * @brief Flush MPTCP addresses.
-         *
-         * @param[in] pm The mptcpd path manager object.
-         *
-         * @todo Improve documentation.
-         *
-         * @return @c 0 if operation was successful. -1 or @c errno
-         *         otherwise.
-         */
-        int (*flush_addrs)(struct mptcpd_pm *pm);
-
-        /**
-         * @brief Set MPTCP resource limits.
-         *
-         * @param[in] pm     The mptcpd path manager object.
-         * @param[in] limits Array of MPTCP resource type/limit pairs.
-         * @param[in] len    Length of the @a limits array.
-         *
-         * @return @c 0 if operation was successful. -1 or @c errno
-         *         otherwise.
-         */
-        int (*set_limits)(struct mptcpd_pm *pm,
-                          struct mptcpd_limit const *limits,
-                          size_t len);
-
-        /**
-         * @brief Get MPTCP resource limits.
-         *
-         * @param[in] pm       The mptcpd path manager object.
-         * @param[in] callback Function to be called when the MPTCP
-         *                     resource limits have been retrieved.
-         * @param[in] data     Data to be passed to the @a callback
-         *                     function.
-         *
-         * @return @c 0 if operation was successful. -1 or @c errno
-         *         otherwise.
-         */
-        int (*get_limits)(struct mptcpd_pm *pm,
-                          mptcpd_pm_get_limits_cb callback,
-                          void *data);
-
-        /**
-         * @brief
-         *
-         * @param[in] pm    The mptcpd path manager object.
-         * @param[in] addr  Local IP address information.
-         * @param[in] flags Flags to be associated with @a addr.
-         */
-        int (*set_flags)(struct mptcpd_pm *pm,
-                         struct sockaddr const *addr,
-                         mptcpd_flags_t flags);
-        ///@}
-
-        /**
-         * @name Client-oriented Path Management Commands
-         *
-         * Client-oriented path management commands that allow for
-         * per-connection path management.
-         */
-        ///@{
         /**
          * @brief Create a new subflow.
          *
@@ -329,7 +212,6 @@ struct mptcpd_pm_cmd_ops
                           struct sockaddr const *local_addr,
                           struct sockaddr const *remote_addr,
                           bool backup);
-        ///@}
 };
 
 /**
@@ -345,17 +227,6 @@ struct mptcpd_kpm_cmd_ops
         /**
          * @privatesection
          */
-        /**
-         * @name Common Path Management Commands
-         *
-         * Path management common to both the upstream and
-         * multipath-tcp.org Linux kernels.
-         *
-         * @todo Consider splitting these commands into
-         *       server-oriented and client-oriented cases.  There
-         *       shouldn't be any overlap between these use cases.
-         */
-        ///@{
         /**
          * @brief Advertise new network address to peers.
          *
@@ -476,7 +347,6 @@ struct mptcpd_kpm_cmd_ops
         int (*set_flags)(struct mptcpd_pm *pm,
                          struct sockaddr const *addr,
                          mptcpd_flags_t flags);
-        ///@}
 };
 
 

--- a/lib/path_manager.c
+++ b/lib/path_manager.c
@@ -79,7 +79,7 @@ bool mptcpd_pm_ready(struct mptcpd_pm const *pm)
 int mptcpd_kpm_add_addr(struct mptcpd_pm *pm,
                         struct sockaddr const *addr,
                         mptcpd_aid_t address_id,
-                        uint32_t flags,
+                        mptcpd_flags_t flags,
                         int index)
 {
         if (pm == NULL || addr == NULL || address_id == 0)

--- a/lib/path_manager.c
+++ b/lib/path_manager.c
@@ -74,11 +74,168 @@ bool mptcpd_pm_ready(struct mptcpd_pm const *pm)
         return pm->family != NULL;
 }
 
+// -------------------------------------------------------------------
+
+int mptcpd_kpm_add_addr(struct mptcpd_pm *pm,
+                        struct sockaddr const *addr,
+                        mptcpd_aid_t address_id,
+                        uint32_t flags,
+                        int index)
+{
+        if (pm == NULL || addr == NULL || address_id == 0)
+                return EINVAL;
+
+        if (!is_pm_ready(pm, __func__))
+                return EAGAIN;
+
+        struct mptcpd_kpm_cmd_ops const *const ops =
+                pm->netlink_pm->kcmd_ops;
+
+        if (ops->add_addr == NULL)
+                return ENOTSUP;
+
+        return ops->add_addr(pm,
+                             addr,
+                             address_id,
+                             flags,
+                             index);
+}
+
+int mptcpd_kpm_remove_addr(struct mptcpd_pm *pm, mptcpd_aid_t address_id)
+{
+        if (pm == NULL || address_id == 0)
+                return EINVAL;
+
+        if (!is_pm_ready(pm, __func__))
+                return EAGAIN;
+
+        struct mptcpd_kpm_cmd_ops const *const ops =
+                pm->netlink_pm->kcmd_ops;
+
+        if (ops == NULL || ops->remove_addr == NULL)
+                return ENOTSUP;
+
+        return ops->remove_addr(pm, address_id);
+}
+
+int mptcpd_kpm_get_addr(struct mptcpd_pm *pm,
+                        mptcpd_aid_t id,
+                        mptcpd_pm_get_addr_cb callback,
+                        void *data)
+{
+        if (pm == NULL || id == 0 || callback == NULL)
+                return EINVAL;
+
+        if (!is_pm_ready(pm, __func__))
+                return EAGAIN;
+
+        struct mptcpd_kpm_cmd_ops const *const ops =
+                pm->netlink_pm->kcmd_ops;
+
+        if (ops == NULL || ops->get_addr == NULL)
+                return ENOTSUP;
+
+        return ops->get_addr(pm, id, callback, data);
+}
+
+int mptcpd_kpm_dump_addrs(struct mptcpd_pm *pm,
+                          mptcpd_pm_get_addr_cb callback,
+                          void *data)
+{
+        if (pm == NULL || callback == NULL)
+                return EINVAL;
+
+        if (!is_pm_ready(pm, __func__))
+                return EAGAIN;
+
+        struct mptcpd_kpm_cmd_ops const *const ops =
+                pm->netlink_pm->kcmd_ops;
+
+        if (ops == NULL || ops->dump_addrs == NULL)
+                return ENOTSUP;
+
+        return ops->dump_addrs(pm, callback, data);
+}
+
+int mptcpd_kpm_flush_addrs(struct mptcpd_pm *pm)
+{
+        if (pm == NULL)
+                return EINVAL;
+
+        if (!is_pm_ready(pm, __func__))
+                return EAGAIN;
+
+        struct mptcpd_kpm_cmd_ops const *const ops =
+                pm->netlink_pm->kcmd_ops;
+
+        if (ops == NULL || ops->flush_addrs == NULL)
+                return ENOTSUP;
+
+        return ops->flush_addrs(pm);
+}
+
+int mptcpd_kpm_set_limits(struct mptcpd_pm *pm,
+                          struct mptcpd_limit const *limits,
+                          size_t len)
+{
+        if (pm == NULL || limits == NULL || len == 0)
+                return EINVAL;
+
+        if (!is_pm_ready(pm, __func__))
+                return EAGAIN;
+
+        struct mptcpd_kpm_cmd_ops const *const ops =
+                pm->netlink_pm->kcmd_ops;
+
+        if (ops == NULL || ops->set_limits == NULL)
+                return ENOTSUP;
+
+        return ops->set_limits(pm, limits, len);
+}
+
+int mptcpd_kpm_get_limits(struct mptcpd_pm *pm,
+                          mptcpd_pm_get_limits_cb callback,
+                          void *data)
+{
+        if (pm == NULL || callback == NULL)
+                return EINVAL;
+
+        if (!is_pm_ready(pm, __func__))
+                return EAGAIN;
+
+        struct mptcpd_kpm_cmd_ops const *const ops =
+                pm->netlink_pm->kcmd_ops;
+
+        if (ops == NULL || ops->get_limits == NULL)
+                return ENOTSUP;
+
+        return ops->get_limits(pm, callback, data);
+}
+
+int mptcpd_kpm_set_flags(struct mptcpd_pm *pm,
+                         struct sockaddr const *addr,
+                         mptcpd_flags_t flags)
+{
+        if (pm == NULL || addr == NULL)
+                return EINVAL;
+
+        if (!is_pm_ready(pm, __func__))
+                return EAGAIN;
+
+        struct mptcpd_kpm_cmd_ops const *const ops =
+                pm->netlink_pm->kcmd_ops;
+
+        if (ops == NULL || ops->set_flags == NULL)
+                return ENOTSUP;
+
+        return ops->set_flags(pm, addr, flags);
+}
+
+// -------------------------------------------------------------------
+
 int mptcpd_pm_add_addr(struct mptcpd_pm *pm,
                        struct sockaddr const *addr,
                        mptcpd_aid_t address_id,
-                       uint32_t flags,
-                       int index,
                        mptcpd_token_t token)
 {
         if (pm == NULL || addr == NULL || address_id == 0)
@@ -90,14 +247,12 @@ int mptcpd_pm_add_addr(struct mptcpd_pm *pm,
         struct mptcpd_pm_cmd_ops const *const ops =
                 pm->netlink_pm->cmd_ops;
 
-        if (ops->add_addr == NULL)
+        if (ops == NULL || ops->add_addr == NULL)
                 return ENOTSUP;
 
         return ops->add_addr(pm,
                              addr,
                              address_id,
-                             flags,
-                             index,
                              token);
 }
 
@@ -114,123 +269,10 @@ int mptcpd_pm_remove_addr(struct mptcpd_pm *pm,
         struct mptcpd_pm_cmd_ops const *const ops =
                 pm->netlink_pm->cmd_ops;
 
-        if (ops->remove_addr == NULL)
+        if (ops == NULL || ops->remove_addr == NULL)
                 return ENOTSUP;
 
         return ops->remove_addr(pm, address_id, token);
-}
-
-int mptcpd_pm_get_addr(struct mptcpd_pm *pm,
-                       mptcpd_aid_t id,
-                       mptcpd_pm_get_addr_cb callback,
-                       void *data)
-{
-        if (pm == NULL || id == 0 || callback == NULL)
-                return EINVAL;
-
-        if (!is_pm_ready(pm, __func__))
-                return EAGAIN;
-
-        struct mptcpd_pm_cmd_ops const *const ops =
-                pm->netlink_pm->cmd_ops;
-
-        if (ops->get_addr == NULL)
-                return ENOTSUP;
-
-        return ops->get_addr(pm, id, callback, data);
-}
-
-int mptcpd_pm_dump_addrs(struct mptcpd_pm *pm,
-                         mptcpd_pm_get_addr_cb callback,
-                         void *data)
-{
-        if (pm == NULL || callback == NULL)
-                return EINVAL;
-
-        if (!is_pm_ready(pm, __func__))
-                return EAGAIN;
-
-        struct mptcpd_pm_cmd_ops const *const ops =
-                pm->netlink_pm->cmd_ops;
-
-        if (ops->dump_addrs == NULL)
-                return ENOTSUP;
-
-        return ops->dump_addrs(pm, callback, data);
-}
-
-int mptcpd_pm_flush_addrs(struct mptcpd_pm *pm)
-{
-        if (pm == NULL)
-                return EINVAL;
-
-        if (!is_pm_ready(pm, __func__))
-                return EAGAIN;
-
-        struct mptcpd_pm_cmd_ops const *const ops =
-                pm->netlink_pm->cmd_ops;
-
-        if (ops->flush_addrs == NULL)
-                return ENOTSUP;
-
-        return ops->flush_addrs(pm);
-}
-
-int mptcpd_pm_set_limits(struct mptcpd_pm *pm,
-                         struct mptcpd_limit const *limits,
-                         size_t len)
-{
-        if (pm == NULL || limits == NULL || len == 0)
-                return EINVAL;
-
-        if (!is_pm_ready(pm, __func__))
-                return EAGAIN;
-
-        struct mptcpd_pm_cmd_ops const *const ops =
-                pm->netlink_pm->cmd_ops;
-
-        if (ops->set_limits == NULL)
-                return ENOTSUP;
-
-        return ops->set_limits(pm, limits, len);
-}
-
-int mptcpd_pm_get_limits(struct mptcpd_pm *pm,
-                         mptcpd_pm_get_limits_cb callback,
-                         void *data)
-{
-        if (pm == NULL || callback == NULL)
-                return EINVAL;
-
-        if (!is_pm_ready(pm, __func__))
-                return EAGAIN;
-
-        struct mptcpd_pm_cmd_ops const *const ops =
-                pm->netlink_pm->cmd_ops;
-
-        if (ops->get_limits == NULL)
-                return ENOTSUP;
-
-        return ops->get_limits(pm, callback, data);
-}
-
-int mptcpd_pm_set_flags(struct mptcpd_pm *pm,
-                        struct sockaddr const *addr,
-                        mptcpd_flags_t flags)
-{
-        if (pm == NULL || addr == NULL)
-                return EINVAL;
-
-        if (!is_pm_ready(pm, __func__))
-                return EAGAIN;
-
-        struct mptcpd_pm_cmd_ops const *const ops =
-                pm->netlink_pm->cmd_ops;
-
-        if (ops->set_flags == NULL)
-                return ENOTSUP;
-
-        return ops->set_flags(pm, addr, flags);
 }
 
 int mptcpd_pm_add_subflow(struct mptcpd_pm *pm,
@@ -250,7 +292,7 @@ int mptcpd_pm_add_subflow(struct mptcpd_pm *pm,
         struct mptcpd_pm_cmd_ops const *const ops =
                 pm->netlink_pm->cmd_ops;
 
-        if (ops->add_subflow == NULL)
+        if (ops == NULL || ops->add_subflow == NULL)
                 return ENOTSUP;
 
         return ops->add_subflow(pm,
@@ -277,7 +319,7 @@ int mptcpd_pm_set_backup(struct mptcpd_pm *pm,
         struct mptcpd_pm_cmd_ops const *const ops =
                 pm->netlink_pm->cmd_ops;
 
-        if (ops->set_backup == NULL)
+        if (ops == NULL || ops->set_backup == NULL)
                 return ENOTSUP;
 
         return ops->set_backup(pm,
@@ -301,7 +343,7 @@ int mptcpd_pm_remove_subflow(struct mptcpd_pm *pm,
         struct mptcpd_pm_cmd_ops const *const ops =
                 pm->netlink_pm->cmd_ops;
 
-        if (ops->remove_subflow == NULL)
+        if (ops == NULL || ops->remove_subflow == NULL)
                 return ENOTSUP;
 
         return ops->remove_subflow(pm,
@@ -309,6 +351,8 @@ int mptcpd_pm_remove_subflow(struct mptcpd_pm *pm,
                                    local_addr,
                                    remote_addr);
 }
+
+// -------------------------------------------------------------------
 
 struct mptcpd_nm const * mptcpd_pm_get_nm(struct mptcpd_pm const *pm)
 {

--- a/lib/path_manager.c
+++ b/lib/path_manager.c
@@ -91,7 +91,7 @@ int mptcpd_kpm_add_addr(struct mptcpd_pm *pm,
         struct mptcpd_kpm_cmd_ops const *const ops =
                 pm->netlink_pm->kcmd_ops;
 
-        if (ops->add_addr == NULL)
+        if (ops == NULL || ops->add_addr == NULL)
                 return ENOTSUP;
 
         return ops->add_addr(pm,

--- a/plugins/path_managers/addr_adv.c
+++ b/plugins/path_managers/addr_adv.c
@@ -59,9 +59,9 @@ static void update_limits(struct mptcpd_pm *pm, int delta)
         if (pm->config->addr_flags & MPTCPD_ADDR_FLAG_SUBFLOW)
                 _limits[1].limit = _limits[0].limit;
 
-        int const result = mptcpd_pm_set_limits(pm,
-                                                _limits,
-                                                L_ARRAY_SIZE(_limits));
+        int const result = mptcpd_kpm_set_limits(pm,
+                                                 _limits,
+                                                 L_ARRAY_SIZE(_limits));
 
         if (result != 0 && result != ENOTSUP)
                 l_warn("can't update limit to %d: %d", subflows, result);
@@ -80,11 +80,10 @@ static void addr_adv_new_local_address(struct mptcpd_interface const *i,
         }
 
         uint32_t       const flags = pm->config->addr_flags;
-        mptcpd_token_t const token = 0;
 
         update_limits(pm, 1);
 
-        if (mptcpd_pm_add_addr(pm, sa, id, flags, i->index, token) != 0)
+        if (mptcpd_kpm_add_addr(pm, sa, id, flags, i->index) != 0)
                 l_error("Unable to advertise IP address.");
 }
 
@@ -104,11 +103,9 @@ static void addr_adv_delete_local_address(
                 return;
         }
 
-        mptcpd_token_t const token = 0;
-
         update_limits(pm, -1);
 
-        if (mptcpd_pm_remove_addr(pm, id, token) != 0)
+        if (mptcpd_kpm_remove_addr(pm, id) != 0)
                 l_error("Unable to stop advertising IP address.");
 }
 

--- a/plugins/path_managers/sspi.c
+++ b/plugins/path_managers/sspi.c
@@ -492,13 +492,9 @@ static void sspi_send_addr(void *data, void *user_data)
                 ((struct sockaddr_in6 const *) addr)->sin6_port = port;
         */
 
-        uint32_t flags = 0;
-
         mptcpd_pm_add_addr(info->pm,
                            addr,
                            address_id,
-                           flags,
-                           info->index,
                            info->token);
 }
 

--- a/src/netlink_pm_mptcp_org.c
+++ b/src/netlink_pm_mptcp_org.c
@@ -176,24 +176,8 @@ static bool append_remote_addr_attr(struct l_genl_msg *msg,
 static int mptcp_org_add_addr(struct mptcpd_pm *pm,
                               struct sockaddr const *addr,
                               mptcpd_aid_t id,
-                              uint32_t const flags,
-                              int index,
                               mptcpd_token_t token)
 {
-        /*
-          MPTCP flags are not needed by multipath-tcp.org kernel to
-          add network address.
-        */
-        if (flags != 0)
-                l_warn("add_addr: MPTCP flags are ignored.");
-
-        /*
-          Network interface index is not needed by multipath-tcp.org
-          kernel to add network address.
-        */
-        if (index != 0)
-                l_warn("add_addr: Network interface index is ignored.");
-
         /*
           Payload:
               Token

--- a/src/netlink_pm_upstream.c
+++ b/src/netlink_pm_upstream.c
@@ -353,16 +353,8 @@ static int upstream_add_addr(struct mptcpd_pm *pm,
                              struct sockaddr const *addr,
                              mptcpd_aid_t address_id,
                              uint32_t flags,
-                             int index,
-                             mptcpd_token_t token)
+                             int index)
 {
-        /*
-          MPTCP connection token is not currently needed by upstream
-          kernel to add network address.
-        */
-        if (token != 0)
-                l_warn("add_addr: MPTCP connection token is ignored.");
-
         /*
           Payload (nested):
               Local address family
@@ -428,17 +420,8 @@ static int upstream_add_addr(struct mptcpd_pm *pm,
 }
 
 static int upstream_remove_addr(struct mptcpd_pm *pm,
-                                mptcpd_aid_t address_id,
-                                mptcpd_token_t token)
+                                mptcpd_aid_t address_id)
 {
-        /*
-          MPTCP connection token is not currently needed by upstream
-          kernel to remove network address.
-        */
-        if (token != 0)
-                l_warn("remove_addr: MPTCP connection token "
-                       "is ignored.");
-
         /*
           Payload (nested):
                   Local address ID
@@ -680,7 +663,7 @@ static int upstream_set_flags(struct mptcpd_pm *pm,
                                   NULL  /* destroy */) == 0;
 }
 
-static struct mptcpd_pm_cmd_ops const cmd_ops =
+static struct mptcpd_kpm_cmd_ops const cmd_ops =
 {
         .add_addr    = upstream_add_addr,
         .remove_addr = upstream_remove_addr,
@@ -693,9 +676,9 @@ static struct mptcpd_pm_cmd_ops const cmd_ops =
 };
 
 static struct mptcpd_netlink_pm const npm = {
-        .name    = MPTCP_PM_NAME,
-        .group   = MPTCP_PM_EV_GRP_NAME,
-        .cmd_ops = &cmd_ops
+        .name     = MPTCP_PM_NAME,
+        .group    = MPTCP_PM_EV_GRP_NAME,
+        .kcmd_ops = &cmd_ops
 };
 
 struct mptcpd_netlink_pm const *mptcpd_get_netlink_pm_upstream(void)

--- a/src/path_manager.c
+++ b/src/path_manager.c
@@ -818,10 +818,11 @@ static void complete_pm_init(struct mptcpd_pm *pm)
           Synchronize mptcpd address ID manager with address IDs
           maintained by the kernel.
          */
-        if (pm->netlink_pm->cmd_ops->dump_addrs != NULL
-            && pm->netlink_pm->cmd_ops->dump_addrs(pm,
-                                                   dump_addrs_callback,
-                                                   pm->idm) != 0)
+        if (pm->netlink_pm->kcmd_ops != NULL
+            && pm->netlink_pm->kcmd_ops->dump_addrs != NULL
+            && pm->netlink_pm->kcmd_ops->dump_addrs(pm,
+                                                    dump_addrs_callback,
+                                                    pm->idm) != 0)
                 l_error("Unable to synchronize ID manager with kernel.");
 
         /**

--- a/tests/test-commands.c
+++ b/tests/test-commands.c
@@ -68,7 +68,7 @@ static struct mptcpd_limit const _limits[] = {
                 .limit = max_subflows
         }
 };
-        
+
 // -------------------------------------------------------------------
 
 static bool is_pm_ready(struct mptcpd_pm const *pm, char const *fname)
@@ -172,15 +172,26 @@ static void test_add_addr(void const *test_data)
         if (!is_pm_ready(pm, __func__))
                 return;
 
+        // Client-oriented path manager.
+        int result = mptcpd_pm_add_addr(pm,
+                                        laddr1,
+                                        test_laddr_id_1,
+                                        test_token_1);
+
+        assert(result == 0 || result == ENOTSUP);
+
+
+        // In-kernel (server-oriented) path manager.
         uint32_t flags = 0;
         int index = 0;
 
-        assert(mptcpd_pm_add_addr(pm,
-                                  laddr1,
-                                  test_laddr_id_1,
-                                  flags,
-                                  index,
-                                  test_token_1) == 0);
+        result = mptcpd_kpm_add_addr(pm,
+                                     laddr1,
+                                     test_laddr_id_1,
+                                     flags,
+                                     index);
+
+        assert(result == 0 || result == ENOTSUP);
 }
 
 static void test_remove_addr(void const *test_data)
@@ -190,9 +201,17 @@ static void test_remove_addr(void const *test_data)
         if (!is_pm_ready(pm, __func__))
                 return;
 
-        assert(mptcpd_pm_remove_addr(pm,
-                                     test_laddr_id_1,
-                                     test_token_1) == 0);
+        // Client-oriented path manager.
+        int result = mptcpd_pm_remove_addr(pm,
+                                           test_laddr_id_1,
+                                           test_token_1);
+
+        assert(result == 0 || result == ENOTSUP);
+
+        // In-kernel (server-oriented) path manager.
+        result = mptcpd_kpm_remove_addr(pm, test_laddr_id_1);
+
+        assert(result == 0 || result == ENOTSUP);
 }
 
 static void test_get_addr(void const *test_data)
@@ -205,10 +224,10 @@ static void test_get_addr(void const *test_data)
         mptcpd_aid_t const id = test_laddr_id_1;
 
         int const result =
-                mptcpd_pm_get_addr(pm,
-                                   id,
-                                   get_addr_callback,
-                                   L_UINT_TO_PTR(id));
+                mptcpd_kpm_get_addr(pm,
+                                    id,
+                                    get_addr_callback,
+                                    L_UINT_TO_PTR(id));
 
         assert(result == 0 || result == ENOTSUP);
 }
@@ -223,9 +242,9 @@ static void test_dump_addrs(void const *test_data)
         mptcpd_aid_t const id = test_laddr_id_1;
 
         int const result =
-                mptcpd_pm_dump_addrs(pm,
-                                     dump_addrs_callback,
-                                     L_UINT_TO_PTR(id));
+                mptcpd_kpm_dump_addrs(pm,
+                                      dump_addrs_callback,
+                                      L_UINT_TO_PTR(id));
 
         assert(result == 0 || result == ENOTSUP);
 }
@@ -237,7 +256,7 @@ static void test_flush_addrs(void const *test_data)
         if (!is_pm_ready(pm, __func__))
                 return;
 
-        int const result = mptcpd_pm_flush_addrs(pm);
+        int const result = mptcpd_kpm_flush_addrs(pm);
 
         /**
          * @bug We could have a resource leak in the kernel here if
@@ -255,9 +274,9 @@ static void test_set_limits(void const *test_data)
         if (!is_pm_ready(pm, __func__))
                 return;
 
-        int const result = mptcpd_pm_set_limits(pm,
-                                                _limits,
-                                                L_ARRAY_SIZE(_limits));
+        int const result = mptcpd_kpm_set_limits(pm,
+                                                 _limits,
+                                                 L_ARRAY_SIZE(_limits));
 
         assert(result == 0 || result == ENOTSUP);
 }
@@ -269,9 +288,9 @@ static void test_get_limits(void const *test_data)
         if (!is_pm_ready(pm, __func__))
                 return;
 
-        int const result = mptcpd_pm_get_limits(pm,
-                                                get_limits_callback,
-                                                NULL);
+        int const result = mptcpd_kpm_get_limits(pm,
+                                                 get_limits_callback,
+                                                 NULL);
 
         assert(result == 0 || result == ENOTSUP);
 }
@@ -285,7 +304,7 @@ static void test_set_flags(void const *test_data)
 
         static mptcpd_flags_t const flags = MPTCPD_ADDR_FLAG_BACKUP;
 
-        int const result = mptcpd_pm_set_flags(pm, laddr1, flags);
+        int const result = mptcpd_kpm_set_flags(pm, laddr1, flags);
 
         assert(result == 0 || result == ENOTSUP);
 }


### PR DESCRIPTION
There should be no overlap between the user space (client-oriented) and in-kernel (server-oriented) variants of the `ADD_ADDR` and `REMOVE_ADDR` related command implementation in mptcpd.  They have different use cases, and the previously forced overlap of the APIs in mptcpd was a source of confusion.  Split the operations specific to the in-kernel path manager to a new `mptcpd_kpm` code namespace to make the difference explicit and more obvious.

