### PR TITLE
Improve mptcpize documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ src/mptcpd
 src/mptcpize
 src/mptcp.service
 man/mptcpd.8
+man/mptcpize.8
 test-driver
 tests/test-network-monitor
 tests/test-plugin

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -1,14 +1,14 @@
 ## SPDX-License-Identifier: BSD-3-Clause
 ##
-## Copyright (c) 2017-2019, Intel Corporation
+## Copyright (c) 2017-2019, 2021, Intel Corporation
 
-man_MANS = mptcpd.8
+man_MANS = mptcpd.8 mptcpize.8
 
 pkgsysconfdir = @sysconfdir@/@PACKAGE@
 
 ## The configure script won't fully expand ${prefix} so leverage
 ## `make' based variable expansion instead.
-mptcpd.8: Makefile mptcpd.8.in
+%.8: Makefile %.8.in
 	$(AM_V_GEN)rm -f $@ $@.tmp; \
 	srcdir=''; \
 		test -f ./$@.in || srcdir=$(srcdir)/; \
@@ -19,6 +19,6 @@ mptcpd.8: Makefile mptcpd.8.in
 	chmod 644 $@.tmp; \
 	mv $@.tmp $@
 
-EXTRA_DIST = mptcpd.8.in
+EXTRA_DIST = mptcpd.8.in mptcpize.8.in
 
 CLEANFILES = $(man_MANS)

--- a/man/mptcpize.8.in
+++ b/man/mptcpize.8.in
@@ -1,0 +1,81 @@
+.\" SPDX-License-Identifier: BSD-3-Clause
+.\"
+.\" Copyright (c) 2021, Intel Corporation
+
+.\" Process this file with
+.\" groff -man -Tascii mptcpize.8
+.\"
+.TH MPTCPIZE 8 "2021-09-23" "Multipath TCP Daemon" "System Management Commands"
+.SH NAME
+mptcpize \- enable MPTCP on existing services
+.SH SYNOPSIS
+.SY mptcpize
+.OP \-?V
+.OP \-\-help
+.OP \-\-usage
+.OP \-\-version
+.B COMMAND
+.YS
+
+.SH DESCRIPTION
+.B mptcpize
+is a program that enables multipath TCP on existing legacy services,
+where
+.B COMMAND
+is one of the following:
+
+.SS
+.BI run\ [ -d ]\  prog \ [ args ]
+Run target program with the specified command line arguments, forcing
+MPTCP socket usage instead of TCP.  If the
+.B -d
+argument is provided, dump messages on
+.B stderr
+when a TCP socket is forced to use MPTCP.
+
+.SS
+.BI enable\  unit
+Update the systemd
+.I unit
+file, forcing the given service to run under the above launcher.
+
+.SS
+.BI disable\  unit
+Update the systemd
+.I unit
+file, removing the above launcher.
+
+
+.SH OPTIONS
+.B mptcpize
+accepts the following command line options:
+
+.TP
+.BR \-? , \-\-help
+display
+.B mptcpize
+help information
+
+.TP
+.B \-\-usage
+display brief
+.B mptcpize
+usage information
+
+.TP
+.BR \-V , \-\-version
+display
+.B mptcpize
+version information
+
+.SH REPORTING BUGS
+Report bugs to
+.MT @PACKAGE_BUGREPORT@
+.ME .
+
+.SH SEE ALSO
+ip-mptcp(8), mptcpd(8)
+
+.\" Local Variables:
+.\" mode: nroff
+.\" End:

--- a/src/mptcpize.c
+++ b/src/mptcpize.c
@@ -36,25 +36,27 @@
 #define MPTCPWRAP_ENV		"LD_PRELOAD="PKGLIBDIR"/libmptcpwrap.so.0.0."LIBREVISION
 
 /* Program documentation. */
-static char argp_doc[] =
-		"mptcpize - a tool to enable MPTCP usage on unmodified legacy services\v"
-		"syntax:\n"
-		"\t mptcpize <options> <cmd>\n"
-		"avaliable <cmd>:\n"
-		"\trun [-d] prog [<args>]    run target program with specified arguments "
-		"forcing MPTCP socket usage instead of TCP"
-		"if the '-d' argument is provided, dump messages on stderr"
-		" when a TCP socket is forced to MPTCP\n"
-		"\tenable <unit>             update the systemd <unit>, forcing"
-		"the given service to run under the above launcher\n"
-		"\tdisable <unit>            update the systemd <unit>, removing"
-		"the above launcher\n";
+static char args_doc[] = "CMD";
 
-static struct argp argp = { 0, 0, 0, argp_doc, 0, 0, 0 };
+static char doc[] =
+        "mptcpize - a tool to enable MPTCP usage on unmodified legacy services\v"
+        "available CMDs:\n"
+        "\trun [-d] prog [<args>]    Run target program with specified\n"
+        "\t                          arguments, forcing MPTCP socket usage\n"
+        "\t                          instead of TCP.  If the '-d' argument\n"
+        "\t                          is provided, dump messages on stderr\n"
+        "\t                          when a TCP socket is forced to MPTCP.\n\n"
+        "\tenable <unit>             Update the systemd <unit>, forcing\n"
+        "\t                          the given service to run under the\n"
+        "\t                          above launcher.\n\n"
+        "\tdisable <unit>            Update the systemd <unit>, removing\n"
+        "\t                          the above launcher.\n";
 
-void help(void)
+static struct argp const argp = { 0, 0, args_doc, doc, 0, 0, 0 };
+
+static void help(void)
 {
-	fprintf(stderr, "%s", argp_doc);
+	argp_help(&argp, stderr, ARGP_HELP_STD_HELP, "mptcpize");
 }
 
 static int run(int argc, char *av[])

--- a/src/mptcpize.c
+++ b/src/mptcpize.c
@@ -40,7 +40,7 @@ static char args_doc[] = "CMD";
 
 static char doc[] =
         "mptcpize - a tool to enable MPTCP usage on unmodified legacy services\v"
-        "available CMDs:\n"
+        "Available CMDs:\n"
         "\trun [-d] prog [<args>]    Run target program with specified\n"
         "\t                          arguments, forcing MPTCP socket usage\n"
         "\t                          instead of TCP.  If the '-d' argument\n"


### PR DESCRIPTION
Add a new mptcpize.8 man page, and clean up help message output from the mptcpize command itself.