### PR TITLE
Correct mptcpd internal initialization order issues.

### DIFF
--- a/include/mptcpd/path_manager.h
+++ b/include/mptcpd/path_manager.h
@@ -271,7 +271,7 @@ MPTCPD_API int mptcpd_kpm_get_addr(struct mptcpd_pm *pm,
                                    mptcpd_aid_t id,
                                    mptcpd_kpm_get_addr_cb_t callback,
                                    void *data,
-                                   mptcpd_kpm_complete_func_t complete);
+                                   mptcpd_complete_func_t complete);
 
 /**
  * @brief Get list (array) of MPTCP network addresses.
@@ -289,7 +289,7 @@ MPTCPD_API int mptcpd_kpm_get_addr(struct mptcpd_pm *pm,
 MPTCPD_API int mptcpd_kpm_dump_addrs(struct mptcpd_pm *pm,
                                      mptcpd_kpm_get_addr_cb_t callback,
                                      void *data,
-                                     mptcpd_kpm_complete_func_t complete);
+                                     mptcpd_complete_func_t complete);
 
 /**
  * @brief Flush MPTCP addresses.

--- a/include/mptcpd/path_manager.h
+++ b/include/mptcpd/path_manager.h
@@ -349,11 +349,14 @@ MPTCPD_API struct mptcpd_nm const *
 mptcpd_pm_get_nm(struct mptcpd_pm const *pm);
 
 /**
- * @brief Get pointer to the underlying MPTCP address ID manager.
+ * @brief Get pointer to the global MPTCP address ID manager.
  *
- * @param[in] pm Mptcpd path manager.
+ * @param[in] pm Mptcpd path manager data.
  *
- * @return Mptcpd MPTCP address ID manager.
+ * @note The global MPTCP address ID manager is meant to track address
+ *       IDs associated with the in-kernel path manager.
+ *
+ * @return Global mptcpd MPTCP address ID manager.
  */
 MPTCPD_API struct mptcpd_idm *
 mptcpd_pm_get_idm(struct mptcpd_pm const *pm);

--- a/include/mptcpd/path_manager.h
+++ b/include/mptcpd/path_manager.h
@@ -262,13 +262,16 @@ MPTCPD_API int mptcpd_kpm_remove_addr(struct mptcpd_pm *pm,
  *                     corresponding to the given MPTCP address @a id
  *                     has been retrieved.
  * @param[in] data     Data to be passed to the @a callback function.
+ * @param[in] complete Function called when the asynchronous
+ *                     @c get_addr call completes.
  *
  * @return @c 0 if operation was successful. -1 or @c errno otherwise.
  */
 MPTCPD_API int mptcpd_kpm_get_addr(struct mptcpd_pm *pm,
                                    mptcpd_aid_t id,
                                    mptcpd_kpm_get_addr_cb_t callback,
-                                   void *data);
+                                   void *data,
+                                   mptcpd_kpm_complete_func_t complete);
 
 /**
  * @brief Get list (array) of MPTCP network addresses.
@@ -278,12 +281,15 @@ MPTCPD_API int mptcpd_kpm_get_addr(struct mptcpd_pm *pm,
  *                     has been retrieved.  This function will be
  *                     called once per dumped network address.
  * @param[in] data     Data to be passed to the @a callback function.
+ * @param[in] complete Function called when the asynchronous
+ *                     @c dump_addrs call completes.
  *
  * @return @c 0 if operation was successful. -1 or @c errno otherwise.
  */
 MPTCPD_API int mptcpd_kpm_dump_addrs(struct mptcpd_pm *pm,
                                      mptcpd_kpm_get_addr_cb_t callback,
-                                     void *data);
+                                     void *data,
+                                     mptcpd_kpm_complete_func_t complete);
 
 /**
  * @brief Flush MPTCP addresses.

--- a/include/mptcpd/path_manager.h
+++ b/include/mptcpd/path_manager.h
@@ -279,7 +279,8 @@ MPTCPD_API int mptcpd_kpm_get_addr(struct mptcpd_pm *pm,
  * @param[in] pm       The mptcpd path manager object.
  * @param[in] callback Function to be called when a network address
  *                     has been retrieved.  This function will be
- *                     called once per dumped network address.
+ *                     called when each address dump is available, or
+ *                     possibly not at all.
  * @param[in] data     Data to be passed to the @a callback function.
  * @param[in] complete Function called when the asynchronous
  *                     @c dump_addrs call completes.

--- a/include/mptcpd/path_manager.h
+++ b/include/mptcpd/path_manager.h
@@ -267,7 +267,7 @@ MPTCPD_API int mptcpd_kpm_remove_addr(struct mptcpd_pm *pm,
  */
 MPTCPD_API int mptcpd_kpm_get_addr(struct mptcpd_pm *pm,
                                    mptcpd_aid_t id,
-                                   mptcpd_pm_get_addr_cb callback,
+                                   mptcpd_kpm_get_addr_cb_t callback,
                                    void *data);
 
 /**
@@ -282,7 +282,7 @@ MPTCPD_API int mptcpd_kpm_get_addr(struct mptcpd_pm *pm,
  * @return @c 0 if operation was successful. -1 or @c errno otherwise.
  */
 MPTCPD_API int mptcpd_kpm_dump_addrs(struct mptcpd_pm *pm,
-                                     mptcpd_pm_get_addr_cb callback,
+                                     mptcpd_kpm_get_addr_cb_t callback,
                                      void *data);
 
 /**

--- a/include/mptcpd/private/netlink_pm.h
+++ b/include/mptcpd/private/netlink_pm.h
@@ -42,13 +42,12 @@ struct mptcpd_netlink_pm
         struct mptcpd_kpm_cmd_ops const *const kcmd_ops;
 };
 
-
-#endif /* MPTCPD_PRIVATE_NETLINK_PM_H */
-
 #ifdef __cplusplus
 }
 #endif
 
+
+#endif /* MPTCPD_PRIVATE_NETLINK_PM_H */
 
 /*
   Local Variables:

--- a/include/mptcpd/private/path_manager.h
+++ b/include/mptcpd/private/path_manager.h
@@ -270,14 +270,17 @@ struct mptcpd_kpm_cmd_ops
          *                     retrieved.
          * @param[in] data     Data to be passed to the @a callback
          *                     function.
+         * @param[in] complete Function called when the asynchronous
+         *                     @c get_addr call completes.
          *
          * @return @c 0 if operation was successful. -1 or @c errno
          *         otherwise.
          */
         int (*get_addr)(struct mptcpd_pm *pm,
                         mptcpd_aid_t id,
-                        mptcpd_pm_get_addr_cb callback,
-                        void *data);
+                        mptcpd_kpm_get_addr_cb_t callback,
+                        void *data,
+                        mptcpd_kpm_complete_func_t complete);
 
         /**
          * @brief Dump list of network addresses.
@@ -285,15 +288,20 @@ struct mptcpd_kpm_cmd_ops
          * @param[in] pm       The mptcpd path manager object.
          * @param[in] callback Function to be called when a dump of
          *                     network addresses has been retrieved.
+         *                     This function will only be called when
+         *                     an address dump is available.
          * @param[in] data     Data to be passed to the @a callback
          *                     function.
+         * @param[in] complete Function called when the asynchronous
+         *                     @c dump_addrs call completes.
          *
          * @return @c 0 if operation was successful. -1 or @c errno
          *         otherwise.
          */
         int (*dump_addrs)(struct mptcpd_pm *pm,
-                          mptcpd_pm_get_addr_cb callback,
-                          void *data);
+                          mptcpd_kpm_get_addr_cb_t callback,
+                          void *data,
+                          mptcpd_kpm_complete_func_t complete);
 
         /**
          * @brief Flush MPTCP addresses.

--- a/include/mptcpd/private/path_manager.h
+++ b/include/mptcpd/private/path_manager.h
@@ -288,8 +288,9 @@ struct mptcpd_kpm_cmd_ops
          * @param[in] pm       The mptcpd path manager object.
          * @param[in] callback Function to be called when a dump of
          *                     network addresses has been retrieved.
-         *                     This function will only be called when
-         *                     an address dump is available.
+         *                     This function will be called when each
+         *                     address dump is available, or possibly
+         *                     not at all.
          * @param[in] data     Data to be passed to the @a callback
          *                     function.
          * @param[in] complete Function called when the asynchronous

--- a/include/mptcpd/private/path_manager.h
+++ b/include/mptcpd/private/path_manager.h
@@ -280,7 +280,7 @@ struct mptcpd_kpm_cmd_ops
                         mptcpd_aid_t id,
                         mptcpd_kpm_get_addr_cb_t callback,
                         void *data,
-                        mptcpd_kpm_complete_func_t complete);
+                        mptcpd_complete_func_t complete);
 
         /**
          * @brief Dump list of network addresses.
@@ -301,7 +301,7 @@ struct mptcpd_kpm_cmd_ops
         int (*dump_addrs)(struct mptcpd_pm *pm,
                           mptcpd_kpm_get_addr_cb_t callback,
                           void *data,
-                          mptcpd_kpm_complete_func_t complete);
+                          mptcpd_complete_func_t complete);
 
         /**
          * @brief Flush MPTCP addresses.

--- a/include/mptcpd/types.h
+++ b/include/mptcpd/types.h
@@ -149,7 +149,7 @@ typedef mptcpd_kpm_get_addr_cb_t
 typedef void (*mptcpd_complete_func_t)(void *user_data);
 
 /// Type of function called on async path manager call completion.
-typedef mptcpd_complete_func_t mptcpd_pm_complete_func_t;
+typedef mptcpd_complete_func_t mptcpd_kpm_complete_func_t;
 
 /**
  * @brief Type of function called when MPTCP resource limits are

--- a/include/mptcpd/types.h
+++ b/include/mptcpd/types.h
@@ -117,14 +117,6 @@ typedef void (*mptcpd_kpm_get_addr_cb_t)(
         void *callback_data);
 
 /**
- * @brief Type of function called when an address is available.
- *
- * @deprecated Use @c mptcpd_pm_get_addr_cb_t instead.
- */
-typedef mptcpd_kpm_get_addr_cb_t
-        mptcpd_pm_get_addr_cb __attribute__((deprecated));
-
-/**
  * @brief Type of function called on asynchronous call completion.
  *
  * The mptcpd path manager API has several functions that complete

--- a/include/mptcpd/types.h
+++ b/include/mptcpd/types.h
@@ -109,11 +109,47 @@ struct mptcpd_limit
  * @param[in]     info          Network address information.  @c NULL
  *                              on error.
  * @param[in,out] callback_data Data provided by the caller of
- *                              @c mptcpd_pm_get_addr() or
- *                              @c mptcpd_pm_dump_addrs().
+ *                              @c mptcpd_kpm_get_addr() or
+ *                              @c mptcpd_kpm_dump_addrs().
  */
-typedef void (*mptcpd_pm_get_addr_cb)(struct mptcpd_addr_info const *info,
-                                      void *callback_data);
+typedef void (*mptcpd_kpm_get_addr_cb_t)(
+        struct mptcpd_addr_info const *info,
+        void *callback_data);
+
+/**
+ * @brief Type of function called when an address is available.
+ *
+ * @deprecated Use @c mptcpd_pm_get_addr_cb_t instead.
+ */
+typedef mptcpd_kpm_get_addr_cb_t
+        mptcpd_pm_get_addr_cb __attribute__((deprecated));
+
+/**
+ * @brief Type of function called on asynchronous call completion.
+ *
+ * The mptcpd path manager API has several functions that complete
+ * asynchronously.  Those functions accept a parameter of this type to
+ * allow the caller to be notified of completion of the asynchronous
+ * functions.
+ *
+ * Functions of this type differ from user provided callbacks that are
+ * called when asynchronous results are available in that this type of
+ * function is called regardless of whether or not asynchronous
+ * results are available.  Furthermore, they are only called once at
+ * the very end of the asynchronous call, whereas those called upon
+ * availability of results may be called multiple times for a single
+ * asynchronous call, such as the case @c mptcpd_pm_dump_addrs().
+ *
+ * Functions of this type are suitable for deallocating dynamically
+ * allocated user_data passed to asynchronous calls, for example.
+ *
+ * @param [in,out] user_data Data provided the user at the time of the
+ *                           asynchronous call.
+ */
+typedef void (*mptcpd_complete_func_t)(void *user_data);
+
+/// Type of function called on async path manager call completion.
+typedef mptcpd_complete_func_t mptcpd_pm_complete_func_t;
 
 /**
  * @brief Type of function called when MPTCP resource limits are

--- a/include/mptcpd/types.h
+++ b/include/mptcpd/types.h
@@ -117,6 +117,14 @@ typedef void (*mptcpd_kpm_get_addr_cb_t)(
         void *callback_data);
 
 /**
+ * @brief Type of function called when an address is available.
+ *
+ * @deprecated Use @c mptcpd_pm_get_addr_cb_t instead.
+ */
+typedef mptcpd_kpm_get_addr_cb_t
+        mptcpd_pm_get_addr_cb __attribute__((deprecated));
+
+/**
  * @brief Type of function called on asynchronous call completion.
  *
  * The mptcpd path manager API has several functions that complete

--- a/include/mptcpd/types.h
+++ b/include/mptcpd/types.h
@@ -140,9 +140,6 @@ typedef void (*mptcpd_kpm_get_addr_cb_t)(
  */
 typedef void (*mptcpd_complete_func_t)(void *user_data);
 
-/// Type of function called on async path manager call completion.
-typedef mptcpd_complete_func_t mptcpd_kpm_complete_func_t;
-
 /**
  * @brief Type of function called when MPTCP resource limits are
  *        available.

--- a/include/mptcpd/types.h
+++ b/include/mptcpd/types.h
@@ -103,8 +103,8 @@ struct mptcpd_limit
  * @brief Type of function called when an address is available.
  *
  * The mptcpd path manager will call a function of this type when
- * the result of calling @c mptcpd_pm_get_addr() or
- * @c mptcpd_pm_dump_addrs() is available.
+ * the result of calling @c mptcpd_kpm_get_addr() or
+ * @c mptcpd_kpm_dump_addrs() is available.
  *
  * @param[in]     info          Network address information.  @c NULL
  *                              on error.
@@ -130,7 +130,7 @@ typedef void (*mptcpd_kpm_get_addr_cb_t)(
  * results are available.  Furthermore, they are only called once at
  * the very end of the asynchronous call, whereas those called upon
  * availability of results may be called multiple times for a single
- * asynchronous call, such as the case @c mptcpd_pm_dump_addrs().
+ * asynchronous call, such as the @c mptcpd_kpm_dump_addrs() case.
  *
  * Functions of this type are suitable for deallocating dynamically
  * allocated user_data passed to asynchronous calls, for example.
@@ -148,14 +148,14 @@ typedef mptcpd_complete_func_t mptcpd_kpm_complete_func_t;
  *        available.
  *
  * The mptcpd path manager will call a function of this type when
- * the result of calling @c mptcpd_pm_get_limits() is available.
+ * the result of calling @c mptcpd_kpm_get_limits() is available.
  *
  * @param[in]     limits        Array of MPTCP resource type/limit
  *                              pairs.  @c NULL on error.
  * @param[in]     len           Length of the @a limits array.  Zero
  *                              on error.
  * @param[in,out] callback_data Data provided by the caller of
- *                              @c mptcpd_pm_get_limits().
+ *                              @c mptcpd_kpm_get_limits().
  */
 typedef void (*mptcpd_pm_get_limits_cb)(
         struct mptcpd_limit const *limits,

--- a/lib/path_manager.c
+++ b/lib/path_manager.c
@@ -122,7 +122,7 @@ int mptcpd_kpm_get_addr(struct mptcpd_pm *pm,
                         mptcpd_aid_t id,
                         mptcpd_kpm_get_addr_cb_t callback,
                         void *data,
-                        mptcpd_kpm_complete_func_t complete)
+                        mptcpd_complete_func_t complete)
 {
         if (pm == NULL || id == 0 || callback == NULL)
                 return EINVAL;
@@ -142,7 +142,7 @@ int mptcpd_kpm_get_addr(struct mptcpd_pm *pm,
 int mptcpd_kpm_dump_addrs(struct mptcpd_pm *pm,
                           mptcpd_kpm_get_addr_cb_t callback,
                           void *data,
-                          mptcpd_kpm_complete_func_t complete)
+                          mptcpd_complete_func_t complete)
 {
         if (pm == NULL || callback == NULL)
                 return EINVAL;

--- a/lib/path_manager.c
+++ b/lib/path_manager.c
@@ -121,7 +121,8 @@ int mptcpd_kpm_remove_addr(struct mptcpd_pm *pm, mptcpd_aid_t address_id)
 int mptcpd_kpm_get_addr(struct mptcpd_pm *pm,
                         mptcpd_aid_t id,
                         mptcpd_kpm_get_addr_cb_t callback,
-                        void *data)
+                        void *data,
+                        mptcpd_kpm_complete_func_t complete)
 {
         if (pm == NULL || id == 0 || callback == NULL)
                 return EINVAL;
@@ -135,12 +136,13 @@ int mptcpd_kpm_get_addr(struct mptcpd_pm *pm,
         if (ops == NULL || ops->get_addr == NULL)
                 return ENOTSUP;
 
-        return ops->get_addr(pm, id, callback, data);
+        return ops->get_addr(pm, id, callback, data, complete);
 }
 
 int mptcpd_kpm_dump_addrs(struct mptcpd_pm *pm,
                           mptcpd_kpm_get_addr_cb_t callback,
-                          void *data)
+                          void *data,
+                          mptcpd_kpm_complete_func_t complete)
 {
         if (pm == NULL || callback == NULL)
                 return EINVAL;
@@ -154,7 +156,7 @@ int mptcpd_kpm_dump_addrs(struct mptcpd_pm *pm,
         if (ops == NULL || ops->dump_addrs == NULL)
                 return ENOTSUP;
 
-        return ops->dump_addrs(pm, callback, data);
+        return ops->dump_addrs(pm, callback, data, complete);
 }
 
 int mptcpd_kpm_flush_addrs(struct mptcpd_pm *pm)

--- a/lib/path_manager.c
+++ b/lib/path_manager.c
@@ -120,7 +120,7 @@ int mptcpd_kpm_remove_addr(struct mptcpd_pm *pm, mptcpd_aid_t address_id)
 
 int mptcpd_kpm_get_addr(struct mptcpd_pm *pm,
                         mptcpd_aid_t id,
-                        mptcpd_pm_get_addr_cb callback,
+                        mptcpd_kpm_get_addr_cb_t callback,
                         void *data)
 {
         if (pm == NULL || id == 0 || callback == NULL)
@@ -139,7 +139,7 @@ int mptcpd_kpm_get_addr(struct mptcpd_pm *pm,
 }
 
 int mptcpd_kpm_dump_addrs(struct mptcpd_pm *pm,
-                          mptcpd_pm_get_addr_cb callback,
+                          mptcpd_kpm_get_addr_cb_t callback,
                           void *data)
 {
         if (pm == NULL || callback == NULL)

--- a/src/netlink_pm_upstream.c
+++ b/src/netlink_pm_upstream.c
@@ -58,7 +58,7 @@ struct get_addr_user_callback
          * called once, whereas the above @c get_addr callback may be
          * called multiple times during a @c dump_addrs call.
          */
-        mptcpd_kpm_complete_func_t complete;
+        mptcpd_complete_func_t complete;
 
         /// Callback is for a dump_addrs call.
         bool dump;
@@ -494,7 +494,7 @@ static int upstream_get_addr(struct mptcpd_pm *pm,
                              mptcpd_aid_t address_id,
                              mptcpd_kpm_get_addr_cb_t callback,
                              void *data,
-                             mptcpd_kpm_complete_func_t complete)
+                             mptcpd_complete_func_t complete)
 {
         /*
           Payload (nested):
@@ -542,7 +542,7 @@ static int upstream_get_addr(struct mptcpd_pm *pm,
 static int upstream_dump_addrs(struct mptcpd_pm *pm,
                                mptcpd_kpm_get_addr_cb_t callback,
                                void *data,
-                               mptcpd_kpm_complete_func_t complete)
+                               mptcpd_complete_func_t complete)
 {
         /*
           Payload:

--- a/src/netlink_pm_upstream.c
+++ b/src/netlink_pm_upstream.c
@@ -45,10 +45,20 @@
 struct get_addr_user_callback
 {
         /// User supplied get_addr/dump_addrs callback.
-        mptcpd_pm_get_addr_cb get_addr;
+        mptcpd_kpm_get_addr_cb_t get_addr;
 
         /// User data to be passed to one of the above callback.
         void *data;
+
+        /**
+         * Function to be called upon completion of the
+         * get_addr/dump_addrs call.  This function is called
+         * regardless of whether or not the get_addr/dump_addrs call
+         * asynchronously returns a network address.  It is also only
+         * called once, whereas the above @c get_addr callback may be
+         * called multiple times during a @c dump_addrs call.
+         */
+        mptcpd_kpm_complete_func_t complete;
 
         /// Callback is for a dump_addrs call.
         bool dump;
@@ -228,6 +238,16 @@ static void get_addr_callback(struct l_genl_msg *msg, void *user_data)
 
         // Pass the results to the user.
         cb->get_addr(&addr, cb->data);
+}
+
+static void get_addr_user_callback_free(void *data)
+{
+        struct get_addr_user_callback *const cb = data;
+
+        if (cb->complete != NULL)
+                cb->complete(cb->data);
+
+        l_free(cb);
 }
 
 static bool append_addr_attr(struct l_genl_msg *msg,
@@ -472,8 +492,9 @@ static int upstream_remove_addr(struct mptcpd_pm *pm,
 
 static int upstream_get_addr(struct mptcpd_pm *pm,
                              mptcpd_aid_t address_id,
-                             mptcpd_pm_get_addr_cb callback,
-                             void *data)
+                             mptcpd_kpm_get_addr_cb_t callback,
+                             void *data,
+                             mptcpd_kpm_complete_func_t complete)
 {
         /*
           Payload (nested):
@@ -507,18 +528,21 @@ static int upstream_get_addr(struct mptcpd_pm *pm,
 
         cb->get_addr = callback;
         cb->data     = data;
+        cb->complete = complete;
         cb->dump     = false;
 
-        return l_genl_family_send(pm->family,
-                                  msg,
-                                  get_addr_callback,
-                                  cb,     /* user data */
-                                  l_free  /* destroy */) == 0;
+        return l_genl_family_send(
+                pm->family,
+                msg,
+                get_addr_callback,
+                cb,     /* user data */
+                get_addr_user_callback_free  /* destroy */) == 0;
 }
 
 static int upstream_dump_addrs(struct mptcpd_pm *pm,
-                               mptcpd_pm_get_addr_cb callback,
-                               void *data)
+                               mptcpd_kpm_get_addr_cb_t callback,
+                               void *data,
+                               mptcpd_kpm_complete_func_t complete)
 {
         /*
           Payload:
@@ -533,13 +557,15 @@ static int upstream_dump_addrs(struct mptcpd_pm *pm,
 
         cb->get_addr = callback;
         cb->data     = data;
+        cb->complete = complete;
         cb->dump     = true;
 
-        return l_genl_family_dump(pm->family,
-                                  msg,
-                                  get_addr_callback,
-                                  cb,     /* user data */
-                                  l_free  /* destroy */) == 0;
+        return l_genl_family_dump(
+                pm->family,
+                msg,
+                get_addr_callback,
+                cb,     /* user data */
+                get_addr_user_callback_free  /* destroy */) == 0;
 }
 
 static int upstream_flush_addrs(struct mptcpd_pm *pm)

--- a/tests/test-commands.c
+++ b/tests/test-commands.c
@@ -227,7 +227,8 @@ static void test_get_addr(void const *test_data)
                 mptcpd_kpm_get_addr(pm,
                                     id,
                                     get_addr_callback,
-                                    L_UINT_TO_PTR(id));
+                                    L_UINT_TO_PTR(id),
+                                    NULL);
 
         assert(result == 0 || result == ENOTSUP);
 }
@@ -244,7 +245,8 @@ static void test_dump_addrs(void const *test_data)
         int const result =
                 mptcpd_kpm_dump_addrs(pm,
                                       dump_addrs_callback,
-                                      L_UINT_TO_PTR(id));
+                                      L_UINT_TO_PTR(id),
+                                      NULL);
 
         assert(result == 0 || result == ENOTSUP);
 }

--- a/tests/test-commands.c
+++ b/tests/test-commands.c
@@ -39,6 +39,8 @@ struct test_info
         bool tests_called;
 };
 
+static int dump_addrs_complete_count;
+
 // -------------------------------------------------------------------
 
 static struct sockaddr const *const laddr1 =
@@ -120,6 +122,13 @@ static void dump_addrs_callback(struct mptcpd_addr_info const *info,
         struct sockaddr const *const addr = laddr1;
         assert(sockaddr_is_equal(addr,
                                  (struct sockaddr *) &info->addr));
+}
+
+static void dump_addrs_complete(void *user_data)
+{
+        (void) user_data;
+
+        dump_addrs_complete_count++;
 }
 
 static void get_limits_callback(struct mptcpd_limit const *limits,
@@ -246,7 +255,7 @@ static void test_dump_addrs(void const *test_data)
                 mptcpd_kpm_dump_addrs(pm,
                                       dump_addrs_callback,
                                       L_UINT_TO_PTR(id),
-                                      NULL);
+                                      dump_addrs_complete);
 
         assert(result == 0 || result == ENOTSUP);
 }
@@ -502,6 +511,8 @@ int main(void)
           family appeared.
          */
         assert(info.tests_called);
+
+        assert(dump_addrs_complete_count == 1);
 
         l_idle_remove(idle);
         l_genl_remove_family_watch(genl, watch_id);


### PR DESCRIPTION
Mptcpd synchronizes its internal state with the kernel at process start, and then continues with initialization such as plugin load and trigger the "pm_ready" callback.  However, the kernel sync operation completes asynchronously meaning the kernel isn't actually "ready" when the plugins are loaded and "pm_ready" callback is triggered.

Introduce a new "`complete`" function parameter to mptcpd path manager command functions that complete asynchronously, e.g. `dump_addrs`, that is called when the operation completes.   The "`complete`" function differs from user provided callbacks that are called when asynchronous results are available in that it is called regardless of whether or not asynchronous results are available.  Furthermore, they are only called once at the very end of the asynchronous call, whereas those called upon availability of results may be called multiple times for a single asynchronous call, such as the case for `dump_addrs`.

Leverage the new "`complete`" function parameter to force correct initialization order of internal mptcpd path manager components.  In particular, the `dump_addrs` call used to sync kernel/mptcpd state now completes before continuing with things like mptcpd plugin load.  This allows internal mptcpd state to be stable and consistent prior to plugin load, and before the "`pm_ready`" callback is triggered.
    
MPTCP path management generic netlink event handlers are also now registered after plugins are loaded since there is no point handling events without the plugins.
