### PR TITLE
Load-plugins related issues fixes

### DIFF
--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -291,7 +291,7 @@ static void load_plugins_queue(char const *dir,
                 l_queue_get_entries((struct l_queue *) plugins_to_load);
 
         while (entry) {
-                char const *const plugin_name = (char *) entry->data;
+                char *plugin_name = (char *) entry->data;
                 char *const path = l_strdup_printf("%s/%s.so",
                                                    dir,
                                                    plugin_name);
@@ -377,12 +377,11 @@ static int load_plugins(char const *dir,
 
         int ret = 0;
 
-        if (plugins_to_load)
+        if (plugins_to_load) {
                 load_plugins_queue(dir, plugins_to_load);
-        else
+                (void) close(fd);
+        } else
                 ret = load_plugins_all(fd, dir);
-
-        (void) close(fd);
 
         // Initialize all loaded plugins.
         l_queue_foreach(_plugin_infos, init_plugin, pm);

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -380,8 +380,14 @@ static int load_plugins(char const *dir,
         if (plugins_to_load) {
                 load_plugins_queue(dir, plugins_to_load);
                 (void) close(fd);
-        } else
+        } else {
                 ret = load_plugins_all(fd, dir);
+                /*
+                  No need call close() since the fdopendir() call in
+                  load_plugins_all() claims ownership of the file
+                  descriptor.  There is no ref count bump.
+                */
+        }
 
         // Initialize all loaded plugins.
         l_queue_foreach(_plugin_infos, init_plugin, pm);

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -291,7 +291,7 @@ static void load_plugins_queue(char const *dir,
                 l_queue_get_entries((struct l_queue *) plugins_to_load);
 
         while (entry) {
-                char *plugin_name = (char *) entry->data;
+                char const *const plugin_name = (char *) entry->data;
                 char *const path = l_strdup_printf("%s/%s.so",
                                                    dir,
                                                    plugin_name);
@@ -377,11 +377,12 @@ static int load_plugins(char const *dir,
 
         int ret = 0;
 
-        if (plugins_to_load) {
+        if (plugins_to_load)
                 load_plugins_queue(dir, plugins_to_load);
-                (void) close(fd);
-        } else
+        else
                 ret = load_plugins_all(fd, dir);
+
+        (void) close(fd);
 
         // Initialize all loaded plugins.
         l_queue_foreach(_plugin_infos, init_plugin, pm);

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -291,11 +291,18 @@ static void load_plugins_queue(char const *dir,
                 l_queue_get_entries((struct l_queue *) plugins_to_load);
 
         while (entry) {
-                char *plugin_name = (char *) entry->data;
+                char const *const plugin_name = (char *) entry->data;
                 char *const path = l_strdup_printf("%s/%s.so",
                                                    dir,
                                                    plugin_name);
 
+                /*
+                   No need to verify if the file exists or if it's
+                   readable since the dlopen() call in load_plugin()
+                   returns NULL if it's not the case. Additional
+                   verification, using for example access(), would only
+                   introduce a TOCTOU race condition.
+                 */
                 load_plugin(path);
 
                 l_free(path);

--- a/man/mptcpd.8.in
+++ b/man/mptcpd.8.in
@@ -119,7 +119,7 @@ overriding plugin priorities
 .TP
 .BI \-\-load\-plugins= PLUGINS
 set plugins to load on startup, where
-.I PLUGINS,
+.I PLUGINS 
 is a comma separated list containing one or more plugin names
 
 .TP

--- a/man/mptcpd.8.in
+++ b/man/mptcpd.8.in
@@ -119,8 +119,8 @@ overriding plugin priorities
 .TP
 .BI \-\-load\-plugins= PLUGINS
 set plugins to load on startup, where
-.I PLUGINS ,
-is a comma separated list containing one or more plugin names.
+.I PLUGINS,
+is a comma separated list containing one or more plugin names
 
 .TP
 .BR \-V , \-\-version

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -862,7 +862,7 @@ void mptcpd_config_destroy(struct mptcpd_config *config)
                 return;
 
         l_queue_destroy((struct l_queue *) config->plugins_to_load,
-                        l_free);
+                        free);
         l_free((char *) config->default_plugin);
         l_free((char *) config->plugin_dir);
         l_free(config);

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -325,10 +325,12 @@ static void set_plugins_to_load(struct mptcpd_config *config,
         while (token) {
                 l_queue_push_tail(
                         (struct l_queue *) config->plugins_to_load,
-                        token);
+                        strdup(token));
 
                 token = strtok(NULL, ",");
         }
+
+        l_free((char *) plugins);
 }
 
 // ---------------------------------------------------------------
@@ -813,7 +815,7 @@ struct mptcpd_config *mptcpd_config_create(int argc, char *argv[])
                 && check_config(config);
 
         l_queue_destroy((struct l_queue *) sys_config.plugins_to_load,
-                        NULL);
+                        l_free);
         l_free((char *) sys_config.default_plugin);
         l_free((char *) sys_config.plugin_dir);
 
@@ -860,7 +862,7 @@ void mptcpd_config_destroy(struct mptcpd_config *config)
                 return;
 
         l_queue_destroy((struct l_queue *) config->plugins_to_load,
-                        NULL);
+                        l_free);
         l_free((char *) config->default_plugin);
         l_free((char *) config->plugin_dir);
         l_free(config);

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -317,11 +317,11 @@ static void set_default_plugin(struct mptcpd_config *config,
  * @param[in]     plugins Comma separated list of plugins to load.
  */
 static void set_plugins_to_load(struct mptcpd_config *config,
-                                char *plugins)
+                                char const *plugins)
 {
         config->plugins_to_load = l_queue_new();
 
-        char *token = strtok(plugins, ",");
+        char *token = strtok((char *) plugins, ",");
         while (token) {
                 l_queue_push_tail(
                         (struct l_queue *) config->plugins_to_load,
@@ -812,6 +812,8 @@ struct mptcpd_config *mptcpd_config_create(int argc, char *argv[])
                 && merge_config(config, &def_config)
                 && check_config(config);
 
+        l_queue_destroy((struct l_queue *) sys_config.plugins_to_load,
+                        NULL);
         l_free((char *) sys_config.default_plugin);
         l_free((char *) sys_config.plugin_dir);
 

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -321,7 +321,7 @@ static void set_plugins_to_load(struct mptcpd_config *config,
 {
         config->plugins_to_load = l_queue_new();
 
-        char *token = strtok((char *) plugins, ",");
+        char *token = strtok(plugins, ",");
         while (token) {
                 l_queue_push_tail(
                         (struct l_queue *) config->plugins_to_load,

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -325,7 +325,7 @@ static void set_plugins_to_load(struct mptcpd_config *config,
         while (token) {
                 l_queue_push_tail(
                         (struct l_queue *) config->plugins_to_load,
-                        strdup(token));
+                        l_strdup(token));
 
                 token = strtok(NULL, ",");
         }
@@ -815,7 +815,7 @@ struct mptcpd_config *mptcpd_config_create(int argc, char *argv[])
                 && check_config(config);
 
         l_queue_destroy((struct l_queue *) sys_config.plugins_to_load,
-                        free);
+                        l_free);
         l_free((char *) sys_config.default_plugin);
         l_free((char *) sys_config.plugin_dir);
 
@@ -862,7 +862,7 @@ void mptcpd_config_destroy(struct mptcpd_config *config)
                 return;
 
         l_queue_destroy((struct l_queue *) config->plugins_to_load,
-                        free);
+                        l_free);
         l_free((char *) config->default_plugin);
         l_free((char *) config->plugin_dir);
         l_free(config);

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -317,7 +317,7 @@ static void set_default_plugin(struct mptcpd_config *config,
  * @param[in]     plugins Comma separated list of plugins to load.
  */
 static void set_plugins_to_load(struct mptcpd_config *config,
-                                char const *plugins)
+                                char *plugins)
 {
         config->plugins_to_load = l_queue_new();
 

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -815,7 +815,7 @@ struct mptcpd_config *mptcpd_config_create(int argc, char *argv[])
                 && check_config(config);
 
         l_queue_destroy((struct l_queue *) sys_config.plugins_to_load,
-                        l_free);
+                        free);
         l_free((char *) sys_config.default_plugin);
         l_free((char *) sys_config.plugin_dir);
 

--- a/tests/test-plugin.c
+++ b/tests/test-plugin.c
@@ -26,7 +26,7 @@
 #include "test-plugin.h"
 
 
-static bool run_plugin_load(mode_t mode, struct l_queue *queue)
+static bool run_plugin_load(mode_t mode, struct l_queue const *queue)
 {
         static char const dir[]            = TEST_PLUGIN_DIR_SECURITY;
         static char const default_plugin[] = TEST_PLUGIN_FOUR;
@@ -42,7 +42,8 @@ static bool run_plugin_load(mode_t mode, struct l_queue *queue)
         int const mode_ok = fchmod(fd, mode);
         assert(mode_ok == 0);
 
-        bool const loaded = mptcpd_plugin_load(dir, default_plugin, queue, pm);
+        bool const loaded =
+                mptcpd_plugin_load(dir, default_plugin, queue, pm);
 
         if (loaded) {
                 call_plugin_ops(&test_count_4,
@@ -136,12 +137,13 @@ static void test_existing_plugins(void const *test_data)
         // Owner and group read/write/execute permissions.
         mode_t const mode = S_IRWXU | S_IRWXG;
 
-        struct l_queue *plugins_list=
-                l_queue_new();
+        struct l_queue *const plugins_list = l_queue_new();
 
         l_queue_push_tail(plugins_list, "four");
 
         bool const loaded = run_plugin_load(mode, plugins_list);
+
+        l_queue_destroy(plugins_list, NULL);
 
         assert(loaded);
 }
@@ -159,12 +161,13 @@ static void test_nonexisting_plugins(void const *test_data)
         // Owner and group read/write/execute permissions.
         mode_t const mode = S_IRWXU | S_IRWXG;
 
-        struct l_queue *plugins_list=
-                l_queue_new();
+        struct l_queue *const plugins_list = l_queue_new();
 
         l_queue_push_tail(plugins_list, "nonexisting_plugin");
 
         bool const loaded = run_plugin_load(mode, plugins_list);
+
+        l_queue_destroy(plugins_list, NULL);
 
         assert(!loaded);
 }
@@ -183,7 +186,8 @@ static void test_plugin_dispatch(void const *test_data)
         static char const *const default_plugin = NULL;
         struct mptcpd_pm *const pm = NULL;
 
-        bool const loaded = mptcpd_plugin_load(dir, default_plugin, NULL, pm);
+        bool const loaded =
+                mptcpd_plugin_load(dir, default_plugin, NULL, pm);
         assert(loaded);
 
         // Notice that we call plugin 1 twice.


### PR DESCRIPTION
Fixed a memory leak inserted with the load-plugins options, where the `plugins_to_load` queue of the `sys_config` variable was not being destroyed on the `mptcpd_config_create` function.

Added a missing `const` qualifier to the input argument `plugins` of the `set_plugins_to_load` function.

Removed an extra space and dot on the man page.