### PR TITLE
implement new address filter based on default route availability

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -14,7 +14,15 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: dependencies
-      run: sudo apt-get -y install autoconf-archive libell-dev pandoc
+      run: sudo apt-get -y install autoconf-archive pandoc git
+    - name: build and install ELL
+      run: |
+        git clone git://git.kernel.org/pub/scm/libs/ell/ell.git
+        cd ell
+        git checkout 0.30
+        ./bootstrap
+        ./configure --prefix=/usr
+        sudo make install
     - name: bootstrap
       run: ./bootstrap
     - name: configure

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,7 +10,15 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: dependencies
-      run: sudo apt-get -y install autoconf-archive libell-dev lcov
+      run: sudo apt-get -y install autoconf-archive lcov pandoc git
+    - name: build and install ELL
+      run: |
+        git clone git://git.kernel.org/pub/scm/libs/ell/ell.git
+        cd ell
+        git checkout 0.30
+        ./bootstrap
+        ./configure --prefix=/usr
+        sudo make install
     - name: bootstrap
       run: ./bootstrap
     - name: configure

--- a/include/mptcpd/types.h
+++ b/include/mptcpd/types.h
@@ -69,6 +69,9 @@ typedef uint32_t mptcpd_flags_t;
 /// Ignore host (loopback) addresses.
 #define MPTCPD_NOTIFY_FLAG_SKIP_HOST (1U << 2)
 
+/// Notify address only if a default route is available from the given interface
+#define MPTCPD_NOTIFY_FLAG_ROUTE_CHECK (1U << 3)
+
 /**
  * @enum mptcpd_limit_types
  *

--- a/man/mptcpd.8.in
+++ b/man/mptcpd.8.in
@@ -98,11 +98,19 @@ ignore (do not notify) [ipv6] link local address updates
 .I skip_loopback
 ignore (do not notify) host (loopback) address updates
 .RE
+.RS
+.TP.
+.I check_route
+notify address only if a default route is available from such
+address and the related device. If the route check fails, it will
+re-done after a little timeout, to allow .e.g. DHCP to configure the
+host properly. Complex Policy routing configuration may confuse or
+circumvent this check.
 .P
 .RS
 These flags determine whether mptpcd plugins will be notified when
 related addresses are updated, e.g.
-.B --notify-flags=existing,skip_link_local
+.B --notify-flags=existing,skip_link_local,check_route
 .RE
 
 .TP

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -170,6 +170,7 @@ struct tok_entry const notify_flags_toks[] = {
         { MPTCPD_NOTIFY_FLAG_EXISTING, "existing" },
         { MPTCPD_NOTIFY_FLAG_SKIP_LL, "skip_link_local" },
         { MPTCPD_NOTIFY_FLAG_SKIP_HOST, "skip_loopback" },
+        { MPTCPD_NOTIFY_FLAG_ROUTE_CHECK, "check_route" },
         { 0, NULL },
 };
 


### PR DESCRIPTION
this change-set implement the functionality discussed in recent public meetings.

Depending on a newly introduced configuration flag, new address are used/notified only if a default route is available for such address/interface.

There are a few quirks due to ipv4 route resolution and libell async notification, see the 3rd patch for the details. 

This should close issue #170 