### PR TITLE
Increase required version ELL to 0.30.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ archive or from a cloned Git `mptcpd` repository, for example.
 
 * Basic `mptcpd` Build Dependencies
   * C compiler (C99 compliant)
-  * [Embedded Linux Library](https://git.kernel.org/pub/scm/libs/ell/ell.git) >= v0.27
+  * [Embedded Linux Library](https://git.kernel.org/pub/scm/libs/ell/ell.git) >= v0.30
   * Argp library (either the GNU libc
     [built-in](https://www.gnu.org/software/libc/manual/html_node/Argp.html)
     or [standalone](http://www.lysator.liu.se/~nisse/misc/))

--- a/configure.ac
+++ b/configure.ac
@@ -183,7 +183,7 @@ AM_CONDITIONAL([BUILDING_DLL], [test "x$enable_shared" = xyes])
 # ---------------------------------------------------------------
 # Checks for libraries.
 # ---------------------------------------------------------------
-ELL_VERSION=0.27  dnl Minimum required version of ELL.
+ELL_VERSION=0.30  dnl Minimum required version of ELL.
 PKG_CHECK_MODULES([ELL],
                   [ell >= $ELL_VERSION])
 AC_SUBST([ELL_VERSION])


### PR DESCRIPTION
The new default route availability based address filter introduced in
PR #179 requires features in ELL >= 0.30.  Adjust the ELL version
check and documentation accordingly.