### PR TITLE
Remove obsolete TODO comments.

### DIFF
--- a/lib/network_monitor.c
+++ b/lib/network_monitor.c
@@ -303,12 +303,6 @@ static bool mptcpd_addr_match(void const *a, void const *b)
                 struct in6_addr const *const sa =
                         (struct in6_addr const*) rhs->addr;
 
-                /**
-                 * @todo Is memcmp() suitable in this case?  Do we
-                 *       need to worry about the existence of
-                 *       uninitialized bytes in the IPv6 address byte
-                 *       array.
-                 */
                 matched = (memcmp(&addr->sin6_addr,
                                   sa,
                                   sizeof(addr->sin6_addr))

--- a/plugins/path_managers/sspi.c
+++ b/plugins/path_managers/sspi.c
@@ -137,12 +137,6 @@ static bool sspi_sockaddr_match(void const *a, void const *b)
                 struct sockaddr_in6 const *const r =
                         (struct sockaddr_in6 const *) rhs;
 
-                /**
-                 * @todo Is memcmp() suitable in this case?
-                 *       Do we need to worry about the
-                 *       existence of uninitialized bytes in
-                 *       the IPv6 address byte array.
-                 */
                 matched = (memcmp(&l->sin6_addr,
                                   &r->sin6_addr,
                                   sizeof(l->sin6_addr))

--- a/tests/lib/sockaddr.c
+++ b/tests/lib/sockaddr.c
@@ -36,11 +36,6 @@ bool sockaddr_is_equal(struct sockaddr const *lhs,
                 (struct sockaddr_in6 const *) rhs;
 
         return l->sin6_port == r->sin6_port
-                /**
-                 * @todo Is memcmp() suitable in this case? Do we need
-                 * to worry about the existence of uninitialized bytes
-                 * in the IPv6 address byte array.
-                 */
                 && memcmp(&l->sin6_addr,
                           &r->sin6_addr,
                           sizeof(l->sin6_addr)) == 0;


### PR DESCRIPTION
TODO comments regarding suitability of memcmp() for IPv6 address
comparisons are not needed since the uninitialized byte concerns
expressed in the comments are incorrect.