### PR TITLE
lib: Correct conflicting _addr_info struct names. 

### DIFF
--- a/lib/network_monitor.c
+++ b/lib/network_monitor.c
@@ -907,6 +907,7 @@ static void handle_rtm_getroute(int error,
 
         (void) type;
         assert(type == RTM_NEWROUTE);
+
         if (ai->address.ss_family == AF_INET) {
                 l_rtnl_route4_extract(data,
                                       len,
@@ -915,8 +916,6 @@ static void handle_rtm_getroute(int error,
                                       &dst,
                                       NULL,
                                       NULL);
-                if (dst)
-                        goto bad_dst;
         } else {
                 l_rtnl_route6_extract(data,
                                       len,
@@ -925,9 +924,10 @@ static void handle_rtm_getroute(int error,
                                       &dst,
                                       NULL,
                                       NULL);
-                if (dst)
-                        goto bad_dst;
         }
+
+        if (dst)
+                goto bad_dst;
 
         if ((int)ifindex != ai->index) {
                 l_info("interface mismatch %d:%d", ifindex, ai->index);


### PR DESCRIPTION
The private `mptcpd_addr_info` structure in `lib/network_monitor.c` has the same name as the one in the public mptcpd API declared in `<mptcpd/addr_info.h>`.  Rename the private one to `nm_addr_info` to avoid confusion and potential namespace conflicts in the future.

Also make the new route check code more closely match the mptcpd coding style.