### PR TITLE
github: Run debug and non-debug mptcpd builds.

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -11,6 +11,10 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        debug: [yes, no]
+
     steps:
     - uses: actions/checkout@v2
     - name: dependencies
@@ -26,7 +30,7 @@ jobs:
     - name: bootstrap
       run: ./bootstrap
     - name: configure
-      run: ./configure
+      run: ./configure --enable-debug=${{ matrix.debug }}
     - name: make
       run: make
     - name: make check

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        debug: [yes, no]
+        debug: [enable-debug, disable-debug]
 
     steps:
     - uses: actions/checkout@v2
@@ -30,7 +30,7 @@ jobs:
     - name: bootstrap
       run: ./bootstrap
     - name: configure
-      run: ./configure --enable-debug=${{ matrix.debug }}
+      run: ./configure --${{ matrix.debug }}
     - name: make
       run: make
     - name: make check


### PR DESCRIPTION
Leverage a GitHub workflow matrix to run debug and non-debug mptcpd
builds using the same set of steps.