### PR TITLE
configure: Replace obsolete AC_PROG_CC_STDC macro.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -43,7 +43,7 @@ AC_CONFIG_MACRO_DIR([m4])
 # ---------------------------------------------------------------
 # Checks for programs.
 # ---------------------------------------------------------------
-AC_PROG_CC_STDC
+AC_PROG_CC
 AM_PROG_CC_C_O
 
 AC_PROG_CXX


### PR DESCRIPTION
Autoconf 2.71 deprecates the AC_PROG_CC_STDC macro.  Use AC_PROG_CC
instead.