### PR TITLE
Make struct mptcpd_addr_info opaque.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ tests/test-configuration
 tests/test-cxx-build
 tests/test-id-manager
 tests/test-sockaddr
+tests/test-addr-info
 tests/mptcpwrap-tester
 tests/*.log
 tests/*.trs

--- a/include/mptcpd/Makefile.am
+++ b/include/mptcpd/Makefile.am
@@ -12,6 +12,7 @@ pkginclude_HEADERS =		\
 	types.h
 
 noinst_HEADERS =			\
+	private/addr_info.h		\
 	private/config.h		\
 	private/configuration.h		\
 	private/id_manager.h		\

--- a/include/mptcpd/addr_info.h
+++ b/include/mptcpd/addr_info.h
@@ -29,7 +29,8 @@ struct mptcpd_addr_info;
  * @return @c sockaddr object containing the underlying network
  *         address information.  Cast to a @c const pointer to a
  *         @c sockaddr_in or @c sockaddr_in6 depending on the address
- *         family in the @c sa_family field.
+ *         family in the @c sa_family field.  @c NULL is returned on
+ *         error.
  */
 MPTCPD_API struct sockaddr const *
 mptcpd_addr_info_get_addr(struct mptcpd_addr_info const *info);
@@ -40,7 +41,7 @@ mptcpd_addr_info_get_addr(struct mptcpd_addr_info const *info);
  * @param[in] info Mptcpd address information.
  *
  * @return MPTCP address ID corresponding to network address
- *         encapsulated by @a info.
+ *         encapsulated by @a info.  0 is returned on error.
  */
 MPTCPD_API mptcpd_aid_t
 mptcpd_addr_info_get_id(struct mptcpd_addr_info const *info);
@@ -51,7 +52,7 @@ mptcpd_addr_info_get_id(struct mptcpd_addr_info const *info);
  * @param[in] info Mptcpd address information.
  *
  * @return Mptcpd flags bitmask associated with the network address
- *         encapsulated by @a info.
+ *         encapsulated by @a info.  0 is returned on error.
  */
 MPTCPD_API mptcpd_flags_t
 mptcpd_addr_info_get_flags(struct mptcpd_addr_info const *info);
@@ -62,7 +63,7 @@ mptcpd_addr_info_get_flags(struct mptcpd_addr_info const *info);
  * @param[in] info Mptcpd address information.
  *
  * @return Network interface index associated with the network address
- *         encapsulated by @a info.
+ *         encapsulated by @a info.  -1 is returned on error.
  */
 MPTCPD_API int
 mptcpd_addr_info_get_index(struct mptcpd_addr_info const *info);

--- a/include/mptcpd/addr_info.h
+++ b/include/mptcpd/addr_info.h
@@ -2,18 +2,13 @@
 /**
  * @file addr_info.h
  *
- * @brief @c mptcpd_addr_info related code.
+ * @brief @c mptcpd_addr_info related functions.
  *
- * Copyright (c) 2020, Intel Corporation
+ * Copyright (c) 2020-2021, Intel Corporation
  */
 
 #ifndef MPTCPD_ADDR_INFO_H
 #define MPTCPD_ADDR_INFO_H
-
-#include <stdbool.h>
-#include <stdint.h>
-#include <sys/socket.h>
-#include <netinet/in.h>
 
 #include <mptcpd/export.h>
 #include <mptcpd/types.h>
@@ -23,47 +18,54 @@
 extern "C" {
 #endif
 
+struct sockaddr;
+struct mptcpd_addr_info;
+
 /**
- * @struct mptcpd_addr_info addr_info.h <mptcpd/addr_info.h>
+ * @brief Get underlying network address related information.
  *
- * @brief Information associated with a network address.
+ * @param[in] info Mptcpd address information.
+ *
+ * @return @c sockaddr object containing the underlying network
+ *         address information.  Cast to a @c const pointer to a
+ *         @c sockaddr_in or @c sockaddr_in6 depending on the address
+ *         family in the @c sa_family field.
  */
-struct mptcpd_addr_info
-{
-        /**
-         * @brief Network address family and IP address.
-         *
-         * @note Cast to @c sockaddr_in or @c sockaddr_in6 depending
-         *       on the address family in the @c ss_family field.
-         */
-        struct sockaddr_storage addr;
+MPTCPD_API struct sockaddr const *
+mptcpd_addr_info_get_addr(struct mptcpd_addr_info const *info);
 
-        /**
-         * MPTCP address ID associated with the network address.
-         *
-         * @note This value will be zero if no ID is associated with
-         *       the address.
-         */
-        mptcpd_aid_t id;
+/**
+ * @brief Get MPTCP address ID.
+ *
+ * @param[in] info Mptcpd address information.
+ *
+ * @return MPTCP address ID corresponding to network address
+ *         encapsulated by @a info.
+ */
+MPTCPD_API mptcpd_aid_t
+mptcpd_addr_info_get_id(struct mptcpd_addr_info const *info);
 
-        /**
-         * @brief MPTCP flags associated with the network address.
-         *
-         * Bitset of MPTCP flags associated with the network address,
-         * e.g. @c MPTCPD_ADDR_FLAG_BACKUP @c |
-         * @c MPTCP_PM_ADDR_FLAG_SUBFLOW.
-         *
-         * @note This value will be zero if no flag bits are set.
-         */
-        uint32_t flags;
+/**
+ * @brief Get mptcpd flags associated with a network address.
+ *
+ * @param[in] info Mptcpd address information.
+ *
+ * @return Mptcpd flags bitmask associated with the network address
+ *         encapsulated by @a info.
+ */
+MPTCPD_API mptcpd_flags_t
+mptcpd_addr_info_get_flags(struct mptcpd_addr_info const *info);
 
-        /**
-         * @brief Network interface index associated with network address.
-         *
-         * @todo Will this value ever be zero, i.e. not set?
-         */
-        int index;
-};
+/**
+ * @brief Get network interface index associated with an address.
+ *
+ * @param[in] info Mptcpd address information.
+ *
+ * @return Network interface index associated with the network address
+ *         encapsulated by @a info.
+ */
+MPTCPD_API int
+mptcpd_addr_info_get_index(struct mptcpd_addr_info const *info);
 
 #ifdef __cplusplus
 }

--- a/include/mptcpd/private/addr_info.h
+++ b/include/mptcpd/private/addr_info.h
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/**
+ * @file private/addr_info.h
+ *
+ * @brief @c mptcpd_addr_info related code.
+ *
+ * Copyright (c) 2020-2021, Intel Corporation
+ */
+
+#ifndef MPTCPD_PRIVATE_ADDR_INFO_H
+#define MPTCPD_PRIVATE_ADDR_INFO_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+
+#include <mptcpd/export.h>
+#include <mptcpd/types.h>
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @struct mptcpd_addr_info addr_info.h <mptcpd/addr_info.h>
+ *
+ * @brief Information associated with a network address.
+ */
+struct mptcpd_addr_info
+{
+        /**
+         * @privatesection
+         */
+
+        /**
+         * @brief Network address family and IP address.
+         *
+         * @note Cast to @c sockaddr_in or @c sockaddr_in6 depending
+         *       on the address family in the @c ss_family field.
+         */
+        struct sockaddr_storage addr;
+
+        /**
+         * MPTCP address ID associated with the network address.
+         *
+         * @note This value will be zero if no ID is associated with
+         *       the address.
+         */
+        mptcpd_aid_t id;
+
+        /**
+         * @brief MPTCP flags associated with the network address.
+         *
+         * Bitset of MPTCP flags associated with the network address,
+         * e.g. @c MPTCPD_ADDR_FLAG_BACKUP @c |
+         * @c MPTCP_PM_ADDR_FLAG_SUBFLOW.
+         *
+         * @note This value will be zero if no flag bits are set.
+         */
+        uint32_t flags;
+
+        /**
+         * @brief Network interface index associated with network address.
+         *
+         * @todo Will this value ever be zero, i.e. not set?
+         */
+        int index;
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif  /* MPTCPD_PRIVATE_ADDR_INFO_H */
+
+
+/*
+  Local Variables:
+  c-file-style: "linux"
+  End:
+*/

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -19,6 +19,7 @@ libmptcpd_la_LDFLAGS = 	\
 	-version-info @LIB_CURRENT@:@LIB_REVISION@:@LIB_AGE@
 
 libmptcpd_la_SOURCES =		\
+	addr_info.c		\
 	id_manager.c		\
 	network_monitor.c	\
 	path_manager.c		\

--- a/lib/addr_info.c
+++ b/lib/addr_info.c
@@ -14,22 +14,34 @@
 struct sockaddr const *
 mptcpd_addr_info_get_addr(struct mptcpd_addr_info const *info)
 {
+        if (info == NULL)
+                return NULL;
+
         return (struct sockaddr const *) &info->addr;
 }
 
 mptcpd_aid_t mptcpd_addr_info_get_id(struct mptcpd_addr_info const *info)
 {
+        if (info == NULL)
+                return 0;  /// @todo Good value to return on error?
+
         return info->id;
 }
 
 mptcpd_flags_t
 mptcpd_addr_info_get_flags(struct mptcpd_addr_info const *info)
 {
+        if (info == NULL)
+                return 0;
+
         return info->flags;
 }
 
 int mptcpd_addr_info_get_index(struct mptcpd_addr_info const *info)
 {
+        if (info == NULL)
+                return -1;
+
         return info->index;
 }
 

--- a/lib/addr_info.c
+++ b/lib/addr_info.c
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/**
+ * @file addr_info.c
+ *
+ * @brief @c mptcpd_addr_info related functions.
+ *
+ * Copyright (c) 2021, Intel Corporation
+ */
+
+#include <mptcpd/addr_info.h>
+#include <mptcpd/private/addr_info.h>
+
+
+struct sockaddr const *
+mptcpd_addr_info_get_addr(struct mptcpd_addr_info const *info)
+{
+        return (struct sockaddr const *) &info->addr;
+}
+
+mptcpd_aid_t mptcpd_addr_info_get_id(struct mptcpd_addr_info const *info)
+{
+        return info->id;
+}
+
+mptcpd_flags_t
+mptcpd_addr_info_get_flags(struct mptcpd_addr_info const *info)
+{
+        return info->flags;
+}
+
+int mptcpd_addr_info_get_index(struct mptcpd_addr_info const *info)
+{
+        return info->index;
+}
+
+
+/*
+  Local Variables:
+  c-file-style: "linux"
+  End:
+*/

--- a/src/netlink_pm_upstream.c
+++ b/src/netlink_pm_upstream.c
@@ -24,7 +24,7 @@
 #include <mptcpd/private/path_manager.h>
 #include <mptcpd/path_manager.h>
 #include <mptcpd/types.h>
-#include <mptcpd/addr_info.h>
+#include <mptcpd/private/addr_info.h>
 #include <mptcpd/private/sockaddr.h>
 
 #include "commands.h"

--- a/src/path_manager.c
+++ b/src/path_manager.c
@@ -35,7 +35,7 @@
 #include <mptcpd/id_manager.h>
 #include <mptcpd/private/sockaddr.h>
 #include <mptcpd/private/configuration.h>
-#include <mptcpd/addr_info.h>
+#include <mptcpd/private/addr_info.h>
 
 // For netlink events.  Same API applies to multipath-tcp.org kernel.
 #include <mptcpd/private/mptcp_upstream.h>

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -27,8 +27,8 @@ check_PROGRAMS =		\
 	test-commands		\
 	test-configuration	\
 	test-id-manager		\
-	test-sockaddr
-
+	test-sockaddr		\
+	test-addr-info
 
 noinst_PROGRAMS = mptcpwrap-tester
 
@@ -103,6 +103,12 @@ test_sockaddr_SOURCES = test-sockaddr.c
 test_sockaddr_LDADD =				\
 	$(top_builddir)/lib/libmptcpd.la	\
 	$(builddir)/lib/libmptcpd_test.la	\
+	$(ELL_LIBS)				\
+	$(CODE_COVERAGE_LIBS)
+
+test_addr_info_SOURCES = test-addr-info.c
+test_addr_info_LDADD =				\
+	$(top_builddir)/lib/libmptcpd.la	\
 	$(ELL_LIBS)				\
 	$(CODE_COVERAGE_LIBS)
 

--- a/tests/test-addr-info.c
+++ b/tests/test-addr-info.c
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/**
+ * @file test-addr-info.c
+ *
+ * @brief mptcpd_addr_info related functions test.
+ *
+ * Copyright (c) 2021, Intel Corporation
+ */
+
+#undef NDEBUG
+#include <assert.h>
+
+#include <ell/log.h>
+#include <ell/test.h>
+
+#include <mptcpd/addr_info.h>
+#include <mptcpd/private/addr_info.h>
+#include <mptcpd/private/sockaddr.h>
+
+    
+static void test_bad_addr_info(void const *test_data)
+{
+        (void) test_data;
+
+        // Check underlying sockaddr.
+        struct sockaddr const *sa = mptcpd_addr_info_get_addr(NULL);
+        assert(sa == NULL);
+
+        // Check MPTCP address ID.
+        mptcpd_aid_t const id = mptcpd_addr_info_get_id(NULL);
+        assert(id == 0);
+
+        // Check mptcpd flags.
+        mptcpd_flags_t const flags = mptcpd_addr_info_get_flags(NULL);
+        assert(flags == 0);
+
+        // Check network interface index.
+        int const index = mptcpd_addr_info_get_index(NULL);
+        assert(index == -1);
+}
+
+static void test_addr_info(void const *test_data)
+{
+        (void) test_data;
+
+        static struct in_addr const addr = {
+                .s_addr = 0x010200C0  // 192.0.2.1
+        };
+
+        static in_port_t const port = 12;
+        
+        struct mptcpd_addr_info info = {
+                .id    = 5,
+                .flags = 10,
+                .index = 2
+        };
+
+        assert(mptcpd_sockaddr_storage_init(&addr,
+                                            NULL,
+                                            port,
+                                            &info.addr));
+
+
+        // Check underlying sockaddr.
+        struct sockaddr const *sa = mptcpd_addr_info_get_addr(&info);
+        assert(sa != NULL && sa->sa_family == AF_INET);
+
+        struct sockaddr_in const *sai = (struct sockaddr_in const *) sa;
+        assert(sai->sin_addr.s_addr == addr.s_addr);
+        assert(sai->sin_port == port);
+
+        // Check MPTCP address ID.
+        mptcpd_aid_t const id = mptcpd_addr_info_get_id(&info);
+        assert(id == info.id);
+
+        // Check mptcpd flags.
+        mptcpd_flags_t const flags = mptcpd_addr_info_get_flags(&info);
+        assert(flags == info.flags);
+
+        // Check network interface index.
+        int const index = mptcpd_addr_info_get_index(&info);
+        assert(index == info.index);
+}
+
+
+int main(int argc, char *argv[])
+{
+        l_log_set_stderr();
+
+        l_test_init(&argc, &argv);
+
+        l_test_add("bad  addr_info", test_bad_addr_info, NULL);
+        l_test_add("good addr_info", test_addr_info,  NULL);
+
+        return l_test_run();
+}
+
+
+/*
+  Local Variables:
+  c-file-style: "linux"
+  End:
+*/

--- a/tests/test-commands.c
+++ b/tests/test-commands.c
@@ -98,11 +98,11 @@ static void get_addr_callback(struct mptcpd_addr_info const *info,
          *      end up not being removed prior to test exit.
          */
         assert(info != NULL);
-        assert(info->id == id);
+        assert(mptcpd_addr_info_get_id(info) == id);
 
         struct sockaddr const *const addr = laddr1;
         assert(sockaddr_is_equal(addr,
-                                 (struct sockaddr *) &info->addr));
+                                 mptcpd_addr_info_get_addr(info)));
 }
 
 static void dump_addrs_callback(struct mptcpd_addr_info const *info,
@@ -117,11 +117,11 @@ static void dump_addrs_callback(struct mptcpd_addr_info const *info,
          *      end up not being removed prior to test exit.
          */
         assert(info != NULL);
-        assert(info->id == id);
+        assert(mptcpd_addr_info_get_id(info) == id);
 
         struct sockaddr const *const addr = laddr1;
         assert(sockaddr_is_equal(addr,
-                                 (struct sockaddr *) &info->addr));
+                                 mptcpd_addr_info_get_addr(info)));
 }
 
 static void dump_addrs_complete(void *user_data)


### PR DESCRIPTION
Make `struct mptcpd_addr_info` opaque, and add accessor functions for the fields in that structure.  This is consistent with other opaque structures in mptcpd.
