### PR TITLE
github: Drop unnecessary pandoc dependency.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: dependencies
-      run: sudo apt-get -y install autoconf-archive lcov pandoc git
+      run: sudo apt-get -y install autoconf-archive lcov git
     - name: build and install ELL
       run: |
         git clone git://git.kernel.org/pub/scm/libs/ell/ell.git


### PR DESCRIPTION
The mptcpd code coverage GitHub workflow does not need the pandoc
package dependency.  Pandoc is only needed when running a `make dist'
or `make distcheck', neither of which is executed in the code coverage
workflow.