### PR TITLE
tests: Override NDEBUG for tests.

### DIFF
--- a/tests/lib/call_plugin.c
+++ b/tests/lib/call_plugin.c
@@ -7,13 +7,14 @@
  * Copyright (c) 2019-2021, Intel Corporation
  */
 
-#undef NDEBUG
-#include <assert.h>
 #include <stdlib.h>
 
 #include <mptcpd/private/plugin.h>
 
 #include "test-plugin.h"
+
+#undef NDEBUG
+#include <assert.h>
 
 
 void call_plugin_ops(struct plugin_call_count const *count,

--- a/tests/plugins/priority/one.c
+++ b/tests/plugins/priority/one.c
@@ -7,10 +7,6 @@
  * Copyright (c) 2019-2021, Intel Corporation
  */
 
-#undef NDEBUG
-
-#include <assert.h>
-
 #include <ell/util.h>  // For L_STRINGIFY needed by l_error().
 #include <ell/log.h>
 
@@ -21,6 +17,10 @@
 #include <mptcpd/plugin.h>
 
 #include "test-plugin.h"
+
+#undef NDEBUG
+#include <assert.h>
+
 
 // ----------------------------------------------------------------
 

--- a/tests/plugins/priority/two.c
+++ b/tests/plugins/priority/two.c
@@ -7,10 +7,6 @@
  * Copyright (c) 2019-2021, Intel Corporation
  */
 
-#undef NDEBUG
-
-#include <assert.h>
-
 #include <ell/util.h>  // For L_STRINGIFY needed by l_error().
 #include <ell/log.h>
 
@@ -21,6 +17,10 @@
 #include <mptcpd/plugin.h>
 
 #include "test-plugin.h"
+
+#undef NDEBUG
+#include <assert.h>
+
 
 // ----------------------------------------------------------------
 

--- a/tests/plugins/security/four.c
+++ b/tests/plugins/security/four.c
@@ -7,10 +7,6 @@
  * Copyright (c) 2019-2021, Intel Corporation
  */
 
-#undef NDEBUG
-
-#include <assert.h>
-
 #include <ell/util.h>  // For L_STRINGIFY needed by l_error().
 #include <ell/log.h>
 
@@ -21,6 +17,10 @@
 #include <mptcpd/plugin.h>
 
 #include "test-plugin.h"
+
+#undef NDEBUG
+#include <assert.h>
+
 
 // ----------------------------------------------------------------
 

--- a/tests/plugins/security/three.c
+++ b/tests/plugins/security/three.c
@@ -7,10 +7,6 @@
  * Copyright (c) 2019-2021, Intel Corporation
  */
 
-#undef NDEBUG
-
-#include <assert.h>
-
 #include <ell/util.h>  // For L_STRINGIFY needed by l_error().
 #include <ell/log.h>
 
@@ -21,6 +17,10 @@
 #include <mptcpd/plugin.h>
 
 #include "test-plugin.h"
+
+#undef NDEBUG
+#include <assert.h>
+
 
 // ----------------------------------------------------------------
 

--- a/tests/test-addr-info.c
+++ b/tests/test-addr-info.c
@@ -7,9 +7,6 @@
  * Copyright (c) 2021, Intel Corporation
  */
 
-#undef NDEBUG
-#include <assert.h>
-
 #include <ell/log.h>
 #include <ell/test.h>
 
@@ -17,7 +14,10 @@
 #include <mptcpd/private/addr_info.h>
 #include <mptcpd/private/sockaddr.h>
 
-    
+#undef NDEBUG
+#include <assert.h>
+
+
 static void test_bad_addr_info(void const *test_data)
 {
         (void) test_data;

--- a/tests/test-commands.c
+++ b/tests/test-commands.c
@@ -7,9 +7,7 @@
  * Copyright (c) 2019-2021, Intel Corporation
  */
 
-#undef NDEBUG
 #include <unistd.h>
-#include <assert.h>
 #include <errno.h>
 #include <error.h>
 #include <stdlib.h>
@@ -38,6 +36,8 @@
 #include <mptcpd/addr_info.h>
 #include <mptcpd/id_manager.h>
 
+#undef NDEBUG
+#include <assert.h>
 
 // -------------------------------------------------------------------
 

--- a/tests/test-configuration.c
+++ b/tests/test-configuration.c
@@ -7,9 +7,6 @@
  * Copyright (c) 2019, 2021, Intel Corporation
  */
 
-#undef NDEBUG
-#include <assert.h>
-
 #include <ell/main.h>
 #include <ell/util.h>      // Needed by <ell/log.h>
 #include <ell/log.h>
@@ -17,6 +14,8 @@
 
 #include <mptcpd/private/configuration.h>  // INTERNAL!
 
+#undef NDEBUG
+#include <assert.h>
 
 #define TEST_PROGRAM_NAME "test-configuration"
 

--- a/tests/test-cxx-build.cpp
+++ b/tests/test-cxx-build.cpp
@@ -7,10 +7,7 @@
  * Copyright (c) 2019, 2021, Intel Corporation
  */
 
-#undef NDEBUG
-
 #include <memory>
-#include <cassert>
 
 #include <ell/main.h>
 #include <ell/idle.h>
@@ -23,6 +20,10 @@
 #include <mptcpd/private/plugin.h>
 
 #include "test-plugin.h"
+
+#undef NDEBUG
+#include <cassert>
+
 
 /**
  * @class test_nm

--- a/tests/test-id-manager.c
+++ b/tests/test-id-manager.c
@@ -7,8 +7,6 @@
  * Copyright (c) 2020-2021, Intel Corporation
  */
 
-#undef NDEBUG
-#include <assert.h>
 #include <stddef.h>
 
 #include <ell/log.h>
@@ -18,6 +16,10 @@
 #include <mptcpd/id_manager.h>
 
 #include "test-plugin.h"  // For test sockaddrs
+
+#undef NDEBUG
+#include <assert.h>
+
 
 /// mptcpd ID manager.
 static struct mptcpd_idm *_idm;

--- a/tests/test-network-monitor.c
+++ b/tests/test-network-monitor.c
@@ -7,10 +7,8 @@
  * Copyright (c) 2018-2020, Intel Corporation
  */
 
-#undef NDEBUG
 #define _DEFAULT_SOURCE  // Enable IFF_... interface flags in <net/if.h>.
 
-#include <assert.h>
 #include <stdlib.h>
 
 #include <arpa/inet.h>   // For inet_ntop().
@@ -24,6 +22,10 @@
 #include <ell/queue.h>
 
 #include <mptcpd/network_monitor.h>
+
+#undef NDEBUG
+#include <assert.h>
+
 
 /// Test user "data".
 static int const coffee = 0xc0ffee;

--- a/tests/test-path-manager.c
+++ b/tests/test-path-manager.c
@@ -7,9 +7,6 @@
  * Copyright (c) 2019-2021, Intel Corporation
  */
 
-#undef NDEBUG
-#include <assert.h>
-
 #include <unistd.h>
 
 #include <ell/main.h>
@@ -24,6 +21,10 @@
 #include <mptcpd/private/configuration.h>  // INTERNAL!
 #include <mptcpd/private/path_manager.h>   // INTERNAL!
 #include <mptcpd/path_manager.h>
+
+#undef NDEBUG
+#include <assert.h>
+
 
 // -------------------------------------------------------------------
 

--- a/tests/test-plugin.c
+++ b/tests/test-plugin.c
@@ -7,15 +7,12 @@
  * Copyright (c) 2018-2021, Intel Corporation
  */
 
-#undef NDEBUG
-
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <stdlib.h>
 #include <stdbool.h>
-#include <assert.h>
 
 #include <ell/test.h>
 #include <ell/queue.h>
@@ -24,6 +21,9 @@
 #include <mptcpd/private/plugin.h>
 
 #include "test-plugin.h"
+
+#undef NDEBUG
+#include <assert.h>
 
 
 static bool run_plugin_load(mode_t mode, struct l_queue const *queue)

--- a/tests/test-sockaddr.c
+++ b/tests/test-sockaddr.c
@@ -7,15 +7,16 @@
  * Copyright (c) 2021, Intel Corporation
  */
 
-#undef NDEBUG
-#include <assert.h>
-
 #include <ell/log.h>
 #include <ell/test.h>
 
 #include <mptcpd/private/sockaddr.h>
 
 #include "test-plugin.h"  // For test sockaddrs
+
+#undef NDEBUG
+#include <assert.h>
+
 
 static void test_bad_sockaddr_init(void const *test_data)
 {


### PR DESCRIPTION
Override the NDEBUG definition in <mptcpd/private/config.h> in
the mptcpd unit tests by moving the #undef NDEBUG and <assert.h>
include directives after all mptcpd includes to prevent the
assert() calls in those tests from being no-ops when building
mptcpd with debugging disabled.

This change set also addresses unused argument errors in
`tests/test-commands.c'.