### PR TITLE
Add support for new upstream kernel PM commands.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ tests/test-commands
 tests/test-configuration
 tests/test-cxx-build
 tests/test-id-manager
+tests/test-listener-manager
 tests/test-sockaddr
 tests/test-addr-info
 tests/test-murmur-hash

--- a/include/linux/mptcp_org.h
+++ b/include/linux/mptcp_org.h
@@ -66,18 +66,20 @@ enum {
  *   - MPTCP_EVENT_REMOVED: token, rem_id
  *       An address has been lost by the peer.
  *
- *   - MPTCP_EVENT_SUB_ESTABLISHED: token, family, saddr4 | saddr6,
- *                                  daddr4 | daddr6, sport, dport, backup,
- *                                  if_idx [, error]
+ *   - MPTCP_EVENT_SUB_ESTABLISHED: token, family, loc_id, rem_id,
+ *                                  saddr4 | saddr6, daddr4 | daddr6, sport,
+ *                                  dport, backup, if_idx [, error]
  *       A new subflow has been established. 'error' should not be set.
  *
- *   - MPTCP_EVENT_SUB_CLOSED: token, family, saddr4 | saddr6, daddr4 | daddr6,
- *                             sport, dport, backup, if_idx [, error]
+ *   - MPTCP_EVENT_SUB_CLOSED: token, family, loc_id, rem_id, saddr4 | saddr6,
+ *                             daddr4 | daddr6, sport, dport, backup, if_idx
+ *                             [, error]
  *       A subflow has been closed. An error (copy of sk_err) could be set if an
  *       error has been detected for this subflow.
  *
- *   - MPTCP_EVENT_SUB_PRIORITY: token, family, saddr4 | saddr6, daddr4 | daddr6,
- *                               sport, dport, backup, if_idx [, error]
+ *   - MPTCP_EVENT_SUB_PRIORITY: token, family, loc_id, rem_id, saddr4 | saddr6,
+ *                               daddr4 | daddr6, sport, dport, backup, if_idx
+ *                               [, error]
  *       The priority of a subflow has changed. 'error' should not be set.
  *
  * Commands for MPTCP:
@@ -88,7 +90,7 @@ enum {
  *       Announce that an address has been lost to the peer.
  *
  *   - MPTCP_CMD_SUB_CREATE: token, family, loc_id, rem_id, daddr4 | daddr6,
- *                           dport [,saddr4 | saddr6, sport, backup, if_idx]
+ *                           dport [, saddr4 | saddr6, sport, backup, if_idx]
  *       Create a new subflow.
  *
  *   - MPTCP_CMD_SUB_DESTROY: token, family, saddr4 | saddr6, daddr4 | daddr6,

--- a/include/linux/mptcp_upstream.h
+++ b/include/linux/mptcp_upstream.h
@@ -4,6 +4,13 @@
 
 #include <linux/const.h>
 #include <linux/types.h>
+#include <linux/in.h>		/* for sockaddr_in			*/
+#include <linux/in6.h>		/* for sockaddr_in6			*/
+#include <linux/socket.h>	/* for sockaddr_storage and sa_family	*/
+
+#ifndef __KERNEL__
+#include <sys/socket.h>		/* for struct sockaddr			*/
+#endif
 
 #define MPTCP_SUBFLOW_FLAG_MCAP_REM		_BITUL(0)
 #define MPTCP_SUBFLOW_FLAG_MCAP_LOC		_BITUL(1)
@@ -76,6 +83,8 @@ enum {
 #define MPTCP_PM_ADDR_FLAG_SIGNAL			(1 << 0)
 #define MPTCP_PM_ADDR_FLAG_SUBFLOW			(1 << 1)
 #define MPTCP_PM_ADDR_FLAG_BACKUP			(1 << 2)
+#define MPTCP_PM_ADDR_FLAG_FULLMESH			(1 << 3)
+#define MPTCP_PM_ADDR_FLAG_IMPLICIT			(1 << 4)
 
 enum {
 	MPTCP_PM_CMD_UNSPEC,
@@ -135,19 +144,21 @@ struct mptcp_info {
  * MPTCP_EVENT_REMOVED: token, rem_id
  * An address has been lost by the peer.
  *
- * MPTCP_EVENT_SUB_ESTABLISHED: token, family, saddr4 | saddr6,
- *                              daddr4 | daddr6, sport, dport, backup,
- *                              if_idx [, error]
+ * MPTCP_EVENT_SUB_ESTABLISHED: token, family, loc_id, rem_id,
+ *                              saddr4 | saddr6, daddr4 | daddr6, sport,
+ *                              dport, backup, if_idx [, error]
  * A new subflow has been established. 'error' should not be set.
  *
- * MPTCP_EVENT_SUB_CLOSED: token, family, saddr4 | saddr6, daddr4 | daddr6,
- *                         sport, dport, backup, if_idx [, error]
+ * MPTCP_EVENT_SUB_CLOSED: token, family, loc_id, rem_id, saddr4 | saddr6,
+ *                         daddr4 | daddr6, sport, dport, backup, if_idx
+ *                         [, error]
  * A subflow has been closed. An error (copy of sk_err) could be set if an
  * error has been detected for this subflow.
  *
- * MPTCP_EVENT_SUB_PRIORITY: token, family, saddr4 | saddr6, daddr4 | daddr6,
- *                           sport, dport, backup, if_idx [, error]
- *       The priority of a subflow has changed. 'error' should not be set.
+ * MPTCP_EVENT_SUB_PRIORITY: token, family, loc_id, rem_id, saddr4 | saddr6,
+ *                           daddr4 | daddr6, sport, dport, backup, if_idx
+ *                           [, error]
+ * The priority of a subflow has changed. 'error' should not be set.
  */
 enum mptcp_event_type {
 	MPTCP_EVENT_UNSPEC = 0,
@@ -184,6 +195,7 @@ enum mptcp_event_attr {
 	MPTCP_ATTR_IF_IDX,	/* s32 */
 	MPTCP_ATTR_RESET_REASON,/* u32 */
 	MPTCP_ATTR_RESET_FLAGS, /* u32 */
+	MPTCP_ATTR_SERVER_SIDE,	/* u8 */
 
 	__MPTCP_ATTR_AFTER_LAST
 };
@@ -198,5 +210,33 @@ enum mptcp_event_attr {
 #define MPTCP_RST_EWQ2BIG	4
 #define MPTCP_RST_EBADPERF	5
 #define MPTCP_RST_EMIDDLEBOX	6
+
+struct mptcp_subflow_data {
+	__u32		size_subflow_data;		/* size of this structure in userspace */
+	__u32		num_subflows;			/* must be 0, set by kernel */
+	__u32		size_kernel;			/* must be 0, set by kernel */
+	__u32		size_user;			/* size of one element in data[] */
+} __attribute__((aligned(8)));
+
+struct mptcp_subflow_addrs {
+	union {
+		__kernel_sa_family_t sa_family;
+		struct sockaddr sa_local;
+		struct sockaddr_in sin_local;
+		struct sockaddr_in6 sin6_local;
+		struct __kernel_sockaddr_storage ss_local;
+	};
+	union {
+		struct sockaddr sa_remote;
+		struct sockaddr_in sin_remote;
+		struct sockaddr_in6 sin6_remote;
+		struct __kernel_sockaddr_storage ss_remote;
+	};
+};
+
+/* MPTCP socket options */
+#define MPTCP_INFO		1
+#define MPTCP_TCPINFO		2
+#define MPTCP_SUBFLOW_ADDRS	3
 
 #endif /* _UAPI_MPTCP_H */

--- a/include/linux/mptcp_upstream.h
+++ b/include/linux/mptcp_upstream.h
@@ -2,15 +2,16 @@
 #ifndef _UAPI_MPTCP_H
 #define _UAPI_MPTCP_H
 
+#ifndef __KERNEL__
+#include <netinet/in.h>		/* for sockaddr_in and sockaddr_in6	*/
+#include <sys/socket.h>		/* for struct sockaddr			*/
+#endif
+
 #include <linux/const.h>
 #include <linux/types.h>
 #include <linux/in.h>		/* for sockaddr_in			*/
 #include <linux/in6.h>		/* for sockaddr_in6			*/
 #include <linux/socket.h>	/* for sockaddr_storage and sa_family	*/
-
-#ifndef __KERNEL__
-#include <sys/socket.h>		/* for struct sockaddr			*/
-#endif
 
 #define MPTCP_SUBFLOW_FLAG_MCAP_REM		_BITUL(0)
 #define MPTCP_SUBFLOW_FLAG_MCAP_LOC		_BITUL(1)

--- a/include/mptcpd/Makefile.am
+++ b/include/mptcpd/Makefile.am
@@ -6,6 +6,7 @@ pkginclude_HEADERS =		\
 	addr_info.h		\
 	export.h		\
 	id_manager.h		\
+	listener_manager.h	\
 	network_monitor.h	\
 	path_manager.h		\
 	plugin.h		\

--- a/include/mptcpd/Makefile.am
+++ b/include/mptcpd/Makefile.am
@@ -17,6 +17,7 @@ noinst_HEADERS =			\
 	private/config.h		\
 	private/configuration.h		\
 	private/id_manager.h		\
+	private/listener_manager.h	\
 	private/mptcp_org.h		\
 	private/mptcp_upstream.h	\
 	private/murmur_hash.h		\

--- a/include/mptcpd/listener_manager.h
+++ b/include/mptcpd/listener_manager.h
@@ -10,8 +10,6 @@
 #ifndef MPTCPD_LISTENER_MANAGER_H
 #define MPTCPD_LISTENER_MANAGER_H
 
-#include <netinet/in.h>
-
 #include <mptcpd/export.h>
 
 
@@ -20,6 +18,7 @@ extern "C" {
 #endif
 
 struct mptcpd_lm;
+struct sockaddr;
 
 /**
  * @brief Listen on the given MPTCP local address.

--- a/include/mptcpd/listener_manager.h
+++ b/include/mptcpd/listener_manager.h
@@ -12,8 +12,13 @@
 
 #include <stdbool.h>
 
+#include <mptcpd/export.h>
 #include <mptcpd/types.h>
 
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 struct l_hashmap;
 struct sockaddr;
@@ -24,14 +29,14 @@ struct sockaddr;
  * @return Pointer to a MPTCP listener manager on success.  @c NULL on
  *         failure.
  */
-struct l_hashmap *mptcpd_lm_create(void);
+MPTCPD_API struct l_hashmap *mptcpd_lm_create(void);
 
 /**
  * @brief Destroy MPTCP listener manager.
  *
  * @param[in,out] lm The mptcpd address listener manager object.
  */
-void mptcpd_lm_destroy(struct l_hashmap *lm);
+MPTCPD_API void mptcpd_lm_destroy(struct l_hashmap *lm);
 
 /**
  * @brief Listen on the given MPTCP local address.
@@ -42,9 +47,9 @@ void mptcpd_lm_destroy(struct l_hashmap *lm);
  *
  * @return @c true on success, and @c false on failure.
  */
-bool mptcpd_lm_listen(struct l_hashmap *lm,
-                      mptcpd_aid_t id,
-                      struct sockaddr const *sa);
+MPTCPD_API bool mptcpd_lm_listen(struct l_hashmap *lm,
+                                 mptcpd_aid_t id,
+                                 struct sockaddr const *sa);
 
 /**
  * @brief Stop listening on a MPTCP local address.
@@ -54,7 +59,12 @@ bool mptcpd_lm_listen(struct l_hashmap *lm,
  *
  * @return @c true on success, and @c false on failure.
  */
-bool mptcpd_lm_close(struct l_hashmap *lm, mptcpd_aid_t id);
+MPTCPD_API bool mptcpd_lm_close(struct l_hashmap *lm, mptcpd_aid_t id);
+
+#ifdef __cplusplus
+}
+#endif
+
 
 #endif /* MPTCPD_LISTENER_MANAGER_H */
 

--- a/include/mptcpd/listener_manager.h
+++ b/include/mptcpd/listener_manager.h
@@ -10,7 +10,7 @@
 #ifndef MPTCPD_LISTENER_MANAGER_H
 #define MPTCPD_LISTENER_MANAGER_H
 
-#include <stdbool.h>
+#include <netinet/in.h>
 
 #include <mptcpd/export.h>
 
@@ -19,7 +19,7 @@
 extern "C" {
 #endif
 
-struct sockaddr;
+
 struct mptcpd_lm;
 
 /**
@@ -31,16 +31,26 @@ struct mptcpd_lm;
  * @param[in] lm The mptcpd address listener manager object.
  * @param[in] sa The MPTCP local address.
  *
- * @return @c true on success, and @c false on failure.
+ * @return Non-zero port in network byte order to which the listener
+ *         was bound, and zero on failure.  An ephemeral port will be
+ *         returned if the port in the local address @a sa is zero.
+ *         The @c sockaddr passed to subsequent calls to
+ *         @c mptcpd_lm_close() should take this into account since
+ *         the mptcpd listener manager will only keep track of
+ *         addresses with non-zero ports, including addresses with
+ *         ephemeral ports.
  */
-MPTCPD_API bool mptcpd_lm_listen(struct mptcpd_lm *lm,
-                                 struct sockaddr const *sa);
+MPTCPD_API in_port_t mptcpd_lm_listen(struct mptcpd_lm *lm,
+                                      struct sockaddr const *sa);
 
 /**
  * @brief Stop listening on a MPTCP local address.
  *
  * @param[in] lm The mptcpd address listener manager object.
- * @param[in] sa The MPTCP local IP address.
+ * @param[in] sa The MPTCP local address with the non-zero port
+ *               returned from @c mptcpd_lm_listen(), i.e. the
+ *               non-zero port provided by the user or the ephemeral
+ *               port chosen by the kernel.
  *
  * @return @c true on success, and @c false on failure.
  */

--- a/include/mptcpd/listener_manager.h
+++ b/include/mptcpd/listener_manager.h
@@ -19,7 +19,6 @@
 extern "C" {
 #endif
 
-
 struct mptcpd_lm;
 
 /**
@@ -28,27 +27,25 @@ struct mptcpd_lm;
  * Create a MPTCP listening socket for the given local address.  This
  * is needed to accept subflows, e.g. during a @c MP_JOIN operation.
  *
- * @param[in] lm The mptcpd address listener manager object.
- * @param[in] sa The MPTCP local address.
+ * @param[in]     lm The mptcpd address listener manager object.
+ * @param[in,out] sa The MPTCP local address.  If the port is zero an
+ *                   ephemeral port will be chosen, and assigned to
+ *                   the appropriate underlying address
+ *                   family-specific port member, e.g. @c sin_port or
+ *                   @c sin6_port.  The port will be in network byte
+ *                   order.
  *
- * @return Non-zero port in network byte order to which the listener
- *         was bound, and zero on failure.  An ephemeral port will be
- *         returned if the port in the local address @a sa is zero.
- *         The @c sockaddr passed to subsequent calls to
- *         @c mptcpd_lm_close() should take this into account since
- *         the mptcpd listener manager will only keep track of
- *         addresses with non-zero ports, including addresses with
- *         ephemeral ports.
+ * @return @c true on success, and @c false on failure.
  */
-MPTCPD_API in_port_t mptcpd_lm_listen(struct mptcpd_lm *lm,
-                                      struct sockaddr const *sa);
+MPTCPD_API bool mptcpd_lm_listen(struct mptcpd_lm *lm,
+                                 struct sockaddr *sa);
 
 /**
  * @brief Stop listening on a MPTCP local address.
  *
  * @param[in] lm The mptcpd address listener manager object.
- * @param[in] sa The MPTCP local address with the non-zero port
- *               returned from @c mptcpd_lm_listen(), i.e. the
+ * @param[in] sa The MPTCP local address with a non-zero port, such as
+ *               the one assigned by @c mptcpd_lm_listen(), i.e. the
  *               non-zero port provided by the user or the ephemeral
  *               port chosen by the kernel.
  *

--- a/include/mptcpd/listener_manager.h
+++ b/include/mptcpd/listener_manager.h
@@ -36,10 +36,10 @@ struct sockaddr;
  *                   @c sin6_port.  The port will be in network byte
  *                   order.
  *
- * @return @c true on success, and @c false on failure.
+ * @return @c 0 if operation was successful. -1 or @c errno otherwise.
  */
-MPTCPD_API bool mptcpd_lm_listen(struct mptcpd_lm *lm,
-                                 struct sockaddr *sa);
+MPTCPD_API int mptcpd_lm_listen(struct mptcpd_lm *lm,
+                                struct sockaddr *sa);
 
 /**
  * @brief Stop listening on a MPTCP local address.
@@ -50,10 +50,10 @@ MPTCPD_API bool mptcpd_lm_listen(struct mptcpd_lm *lm,
  *               non-zero port provided by the user or the ephemeral
  *               port chosen by the kernel.
  *
- * @return @c true on success, and @c false on failure.
+ * @return @c 0 if operation was successful. -1 or @c errno otherwise.
  */
-MPTCPD_API bool mptcpd_lm_close(struct mptcpd_lm *lm,
-                                struct sockaddr const *sa);
+MPTCPD_API int mptcpd_lm_close(struct mptcpd_lm *lm,
+                               struct sockaddr const *sa);
 
 #ifdef __cplusplus
 }

--- a/include/mptcpd/listener_manager.h
+++ b/include/mptcpd/listener_manager.h
@@ -10,6 +10,8 @@
 #ifndef MPTCPD_LISTENER_MANAGER_H
 #define MPTCPD_LISTENER_MANAGER_H
 
+#include <stdbool.h>
+
 #include <mptcpd/export.h>
 
 

--- a/include/mptcpd/listener_manager.h
+++ b/include/mptcpd/listener_manager.h
@@ -13,15 +13,14 @@
 #include <stdbool.h>
 
 #include <mptcpd/export.h>
-#include <mptcpd/types.h>
 
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-struct l_hashmap;
 struct sockaddr;
+struct mptcpd_lm;
 
 /**
  * @brief Create a MPTCP listener manager.
@@ -29,37 +28,36 @@ struct sockaddr;
  * @return Pointer to a MPTCP listener manager on success.  @c NULL on
  *         failure.
  */
-MPTCPD_API struct l_hashmap *mptcpd_lm_create(void);
+MPTCPD_API struct mptcpd_lm *mptcpd_lm_create(void);
 
 /**
  * @brief Destroy MPTCP listener manager.
  *
  * @param[in,out] lm The mptcpd address listener manager object.
  */
-MPTCPD_API void mptcpd_lm_destroy(struct l_hashmap *lm);
+MPTCPD_API void mptcpd_lm_destroy(struct mptcpd_lm *lm);
 
 /**
  * @brief Listen on the given MPTCP local address.
  *
  * @param[in] lm The mptcpd address listener manager object.
- * @param[in] id The MPTCP local address ID.
  * @param[in] sa The MPTCP local address.
  *
  * @return @c true on success, and @c false on failure.
  */
-MPTCPD_API bool mptcpd_lm_listen(struct l_hashmap *lm,
-                                 mptcpd_aid_t id,
+MPTCPD_API bool mptcpd_lm_listen(struct mptcpd_lm *lm,
                                  struct sockaddr const *sa);
 
 /**
  * @brief Stop listening on a MPTCP local address.
  *
  * @param[in] lm The mptcpd address listener manager object.
- * @param[in] id The MPTCP local address ID.
+ * @param[in] sa The MPTCP local IP address.
  *
  * @return @c true on success, and @c false on failure.
  */
-MPTCPD_API bool mptcpd_lm_close(struct l_hashmap *lm, mptcpd_aid_t id);
+MPTCPD_API bool mptcpd_lm_close(struct mptcpd_lm *lm,
+                                struct sockaddr const *sa);
 
 #ifdef __cplusplus
 }

--- a/include/mptcpd/listener_manager.h
+++ b/include/mptcpd/listener_manager.h
@@ -2,7 +2,7 @@
 /**
  * @file listener_manager.h
  *
- * @brief Map of MPTCP local address ID to listener.
+ * @brief Map of MPTCP local address to listener.
  *
  * Copyright (c) 2022, Intel Corporation
  */
@@ -23,22 +23,10 @@ struct sockaddr;
 struct mptcpd_lm;
 
 /**
- * @brief Create a MPTCP listener manager.
- *
- * @return Pointer to a MPTCP listener manager on success.  @c NULL on
- *         failure.
- */
-MPTCPD_API struct mptcpd_lm *mptcpd_lm_create(void);
-
-/**
- * @brief Destroy MPTCP listener manager.
- *
- * @param[in,out] lm The mptcpd address listener manager object.
- */
-MPTCPD_API void mptcpd_lm_destroy(struct mptcpd_lm *lm);
-
-/**
  * @brief Listen on the given MPTCP local address.
+ *
+ * Create a MPTCP listening socket for the given local address.  This
+ * is needed to accept subflows, e.g. during a @c MP_JOIN operation.
  *
  * @param[in] lm The mptcpd address listener manager object.
  * @param[in] sa The MPTCP local address.

--- a/include/mptcpd/path_manager.h
+++ b/include/mptcpd/path_manager.h
@@ -4,7 +4,7 @@
  *
  * @brief mptcpd generic netlink commands.
  *
- * Copyright (c) 2017-2021, Intel Corporation
+ * Copyright (c) 2017-2022, Intel Corporation
  */
 
 #ifndef MPTCPD_LIB_PATH_MANAGER_H
@@ -126,6 +126,9 @@ MPTCPD_API int mptcpd_pm_add_addr(struct mptcpd_pm *pm,
  * @brief Stop advertising network address to peers.
  *
  * @param[in] pm         The mptcpd path manager object.
+ * @param[in] addr       Local IP address and port (zero if unused)
+ *                       that should no longer be advertised through
+ *                       MPTCP.
  * @param[in] address_id MPTCP local address ID to be sent in the
  *                       MPTCP protocol @c REMOVE_ADDR option
  *                       corresponding to the local address that will
@@ -135,6 +138,7 @@ MPTCPD_API int mptcpd_pm_add_addr(struct mptcpd_pm *pm,
  * @return @c 0 if operation was successful. -1 or @c errno otherwise.
  */
 MPTCPD_API int mptcpd_pm_remove_addr(struct mptcpd_pm *pm,
+                                     struct sockaddr const *addr,
                                      mptcpd_aid_t address_id,
                                      mptcpd_token_t token);
 

--- a/include/mptcpd/path_manager.h
+++ b/include/mptcpd/path_manager.h
@@ -372,6 +372,19 @@ mptcpd_pm_get_nm(struct mptcpd_pm const *pm);
 MPTCPD_API struct mptcpd_idm *
 mptcpd_pm_get_idm(struct mptcpd_pm const *pm);
 
+/**
+ * @brief Get pointer to the global MPTCP listener manager.
+ *
+ * @param[in] pm Mptcpd path manager data.
+ *
+ * @note The global MPTCP listener manager tracks MPTCP listening
+ *       sockets associated with a local address.
+ *
+ * @return Global mptcpd MPTCP listener manager.
+ */
+MPTCPD_API struct mptcpd_lm *
+mptcpd_pm_get_lm(struct mptcpd_pm const *pm);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/mptcpd/path_manager.h
+++ b/include/mptcpd/path_manager.h
@@ -119,7 +119,7 @@ MPTCPD_API bool mptcpd_pm_ready(struct mptcpd_pm const *pm);
  * @param[in]     id    MPTCP local address ID.
  * @param[in]     token MPTCP connection token.
  *
- * @return @c 0 if operation was successful. @c errno otherwise.
+ * @return @c 0 if operation was successful. -1 or @c errno otherwise.
  */
 MPTCPD_API int mptcpd_pm_add_addr(struct mptcpd_pm *pm,
                                   struct sockaddr *addr,

--- a/include/mptcpd/path_manager.h
+++ b/include/mptcpd/path_manager.h
@@ -107,18 +107,22 @@ MPTCPD_API bool mptcpd_pm_ready(struct mptcpd_pm const *pm);
 /**
  * @brief Advertise new network address to peers.
  *
- * @param[in] pm    The mptcpd path manager object.
- * @param[in] addr  Local IP address and port to be advertised
- *                  through the MPTCP protocol @c ADD_ADDR
- *                  option.  The port is optional, and is
- *                  ignored if it is zero.
- * @param[in] id    MPTCP local address ID.
- * @param[in] token MPTCP connection token.
+ * @param[in]     pm    The mptcpd path manager object.
+ * @param[in,out] addr  Local IP address and port to be advertised
+ *                      through the MPTCP protocol @c ADD_ADDR
+ *                      option.  If the port is zero an ephemeral port
+ *                      will be chosen, and assigned to the
+ *                      appropriate underlying address family-specific
+ *                      port member, e.g. @c sin_port or
+ *                      @c sin6_port.  The port will be in network
+ *                      byte order.
+ * @param[in]     id    MPTCP local address ID.
+ * @param[in]     token MPTCP connection token.
  *
  * @return @c 0 if operation was successful. @c errno otherwise.
  */
 MPTCPD_API int mptcpd_pm_add_addr(struct mptcpd_pm *pm,
-                                  struct sockaddr const *addr,
+                                  struct sockaddr *addr,
                                   mptcpd_aid_t id,
                                   mptcpd_token_t token);
 
@@ -126,9 +130,8 @@ MPTCPD_API int mptcpd_pm_add_addr(struct mptcpd_pm *pm,
  * @brief Stop advertising network address to peers.
  *
  * @param[in] pm         The mptcpd path manager object.
- * @param[in] addr       Local IP address and port (zero if unused)
- *                       that should no longer be advertised through
- *                       MPTCP.
+ * @param[in] addr       Local IP address and port that should no longer
+ *                       be advertised through MPTCP.
  * @param[in] address_id MPTCP local address ID to be sent in the
  *                       MPTCP protocol @c REMOVE_ADDR option
  *                       corresponding to the local address that will

--- a/include/mptcpd/plugin.h
+++ b/include/mptcpd/plugin.h
@@ -4,7 +4,7 @@
  *
  * @brief mptcpd user space path manager plugin header file.
  *
- * Copyright (c) 2017-2020, Intel Corporation
+ * Copyright (c) 2017-2020, 2022, Intel Corporation
  */
 
 #ifndef MPTCPD_PLUGIN_H
@@ -139,29 +139,33 @@ struct mptcpd_plugin_ops
          * A new MPTCP connection has been created, and pending
          * completion.
          *
-         * @param[in] token  MPTCP connection token.
-         * @param[in] laddr  Local address information.
-         * @param[in] raddr  Remote address information.
-         * @param[in] pm     Opaque pointer to mptcpd path manager
-         *                   object.
+         * @param[in] token       MPTCP connection token.
+         * @param[in] laddr       Local address information.
+         * @param[in] raddr       Remote address information.
+         * @param[in] server_side Server side connection flag.
+         * @param[in] pm          Opaque pointer to mptcpd path
+         *                        manager object.
          */
         void (*new_connection)(mptcpd_token_t token,
                                struct sockaddr const *laddr,
                                struct sockaddr const *raddr,
+                               bool server_side,
                                struct mptcpd_pm *pm);
 
         /**
          * @brief New MPTCP-capable connection has been established.
          *
-         * @param[in] token  MPTCP connection token.
-         * @param[in] laddr  Local address information.
-         * @param[in] raddr  Remote address information.
-         * @param[in] pm     Opaque pointer to mptcpd path manager
-         *                   object.
+         * @param[in] token       MPTCP connection token.
+         * @param[in] laddr       Local address information.
+         * @param[in] raddr       Remote address information.
+         * @param[in] server_side Server side connection flag.
+         * @param[in] pm          Opaque pointer to mptcpd path
+         *                        manager object.
          */
         void (*connection_established)(mptcpd_token_t token,
                                        struct sockaddr const *laddr,
                                        struct sockaddr const *raddr,
+                                       bool server_side,
                                        struct mptcpd_pm *pm);
 
         /**

--- a/include/mptcpd/plugin.h
+++ b/include/mptcpd/plugin.h
@@ -142,7 +142,9 @@ struct mptcpd_plugin_ops
          * @param[in] token       MPTCP connection token.
          * @param[in] laddr       Local address information.
          * @param[in] raddr       Remote address information.
-         * @param[in] server_side Server side connection flag.
+         * @param[in] server_side @c true if this peer was the
+         *                        listener (server), @c false if this
+         *                        peer initiated the connection.
          * @param[in] pm          Opaque pointer to mptcpd path
          *                        manager object.
          */
@@ -158,7 +160,9 @@ struct mptcpd_plugin_ops
          * @param[in] token       MPTCP connection token.
          * @param[in] laddr       Local address information.
          * @param[in] raddr       Remote address information.
-         * @param[in] server_side Server side connection flag.
+         * @param[in] server_side @c true if this peer was the
+         *                        listener (server), @c false if this
+         *                        peer initiated the connection.
          * @param[in] pm          Opaque pointer to mptcpd path
          *                        manager object.
          */

--- a/include/mptcpd/private/listener_manager.h
+++ b/include/mptcpd/private/listener_manager.h
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/**
+ * @file listener_manager.h
+ *
+ * @brief Map of MPTCP local address to listener - private API.
+ *
+ * Copyright (c) 2022, Intel Corporation
+ */
+
+#ifndef MPTCPD_PRIVATE_LISTENER_MANAGER_H
+#define MPTCPD_PRIVATE_LISTENER_MANAGER_H
+
+#include <mptcpd/export.h>
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct mptcpd_lm;
+
+/**
+ * @brief Create a MPTCP listener manager.
+ *
+ * @return Pointer to a MPTCP listener manager on success.  @c NULL on
+ *         failure.
+ */
+MPTCPD_API struct mptcpd_lm *mptcpd_lm_create(void);
+
+/**
+ * @brief Destroy MPTCP listener manager.
+ *
+ * @param[in,out] lm The mptcpd address listener manager object.
+ */
+MPTCPD_API void mptcpd_lm_destroy(struct mptcpd_lm *lm);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* MPTCPD_PRIVATE_LISTENER_MANAGER_H */
+
+
+/*
+  Local Variables:
+  c-file-style: "linux"
+  End:
+*/

--- a/include/mptcpd/private/listener_manager.h
+++ b/include/mptcpd/private/listener_manager.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 /**
- * @file listener_manager.h
+ * @file private/listener_manager.h
  *
  * @brief Map of MPTCP local address to listener - private API.
  *
@@ -33,7 +33,6 @@ MPTCPD_API struct mptcpd_lm *mptcpd_lm_create(void);
  * @param[in,out] lm The mptcpd address listener manager object.
  */
 MPTCPD_API void mptcpd_lm_destroy(struct mptcpd_lm *lm);
-
 
 #ifdef __cplusplus
 }

--- a/include/mptcpd/private/path_manager.h
+++ b/include/mptcpd/private/path_manager.h
@@ -95,7 +95,9 @@ struct mptcpd_pm
          * @brief MPTCP listener manager.
          *
          * The MPTCP listener manager maps MPTCP local addresses to a
-         * listening socket file descriptors bound to those addresses.
+         * listening socket file descriptors bound to those addresses
+         * to allow passive subflow connections (joins) to be
+         * accepted.
          */
         struct mptcpd_lm *lm;
 

--- a/include/mptcpd/private/path_manager.h
+++ b/include/mptcpd/private/path_manager.h
@@ -23,13 +23,13 @@ struct l_genl;
 struct l_genl_family;
 struct l_queue;
 struct l_timeout;
-struct l_hashmap;
 
 struct mptcpd_netlink_pm;
 struct mptcpd_addr_info;
 struct mptcpd_limit;
 struct mptcpd_nm;
 struct mptcpd_idm;
+struct mptcpd_lm;
 
 /**
  * @struct mptcpd_pm path_manager.h <mptcpd/private/path_manager.h>
@@ -92,20 +92,12 @@ struct mptcpd_pm
         struct mptcpd_idm *idm;
 
         /**
-         * @brief MPTCP listener manager map.
+         * @brief MPTCP listener manager.
          *
-         * The underlying hash map used by the MPTCP listener manager
-         * to map a MPTCP local address ID to a MPTCP socket file
-         * descriptor.
-         *
-         * @todo A mptcpd path manager-wide MPTCP listener manager like
-         *       this could be problematic if multiple client-oriented
-         *       plugins attempt to advertise or stop advertising a
-         *       different local addresses with the same MPTCP address ID
-         *       through the mptcpd_pm_add_addr() and
-         *       mptcpd_pm_remove_addr() functions.
+         * The MPTCP listener manager maps MPTCP local addresses to a
+         * listening socket file descriptors bound to those addresses.
          */
-        struct l_hashmap *lm;
+        struct mptcpd_lm *lm;
 
         /// List of @c pm_ops_info objects.
         struct l_queue *event_ops;
@@ -162,15 +154,20 @@ struct mptcpd_pm_cmd_ops
 
         /**
          * @brief Stop advertising network address to peers.
-         * @param[in] pm         The mptcpd path manager object.
-         * @param[in] address_id MPTCP local address ID.
-         * @param[in] token      MPTCP connection token.
+         *
+         * @param[in] pm    The mptcpd path manager object.
+         * @param[in] addr  Local IP address and port (zero if unused)
+         *                  that should no longer be advertised
+         *                  through MPTCP.
+         * @param[in] id    MPTCP local address ID.
+         * @param[in] token MPTCP connection token.
          *
          * @return @c 0 if operation was successful. -1 or @c errno
          *         otherwise.
          */
         int (*remove_addr)(struct mptcpd_pm *pm,
-                           mptcpd_aid_t address_id,
+                           struct sockaddr const *addr,
+                           mptcpd_aid_t id,
                            mptcpd_token_t token);
 
         /**

--- a/include/mptcpd/private/path_manager.h
+++ b/include/mptcpd/private/path_manager.h
@@ -4,7 +4,7 @@
  *
  * @brief mptcpd path manager private interface.
  *
- * Copyright (c) 2017-2021, Intel Corporation
+ * Copyright (c) 2017-2022, Intel Corporation
  */
 
 #ifndef MPTCPD_PRIVATE_PATH_MANAGER_H
@@ -23,6 +23,7 @@ struct l_genl;
 struct l_genl_family;
 struct l_queue;
 struct l_timeout;
+struct l_hashmap;
 
 struct mptcpd_netlink_pm;
 struct mptcpd_addr_info;
@@ -86,9 +87,25 @@ struct mptcpd_pm
          * @brief MPTCP address ID manager.
          *
          * Manager that maps IP addresses to MPTCP address IDs, and
-         * generated IDs as needed..
+         * generated IDs as needed.
          */
         struct mptcpd_idm *idm;
+
+        /**
+         * @brief MPTCP listener manager map.
+         *
+         * The underlying hash map used by the MPTCP listener manager
+         * to map a MPTCP local address ID to a MPTCP socket file
+         * descriptor.
+         *
+         * @todo A mptcpd path manager-wide MPTCP listener manager like
+         *       this could be problematic if multiple client-oriented
+         *       plugins attempt to advertise or stop advertising a
+         *       different local addresses with the same MPTCP address ID
+         *       through the mptcpd_pm_add_addr() and
+         *       mptcpd_pm_remove_addr() functions.
+         */
+        struct l_hashmap *lm;
 
         /// List of @c pm_ops_info objects.
         struct l_queue *event_ops;

--- a/include/mptcpd/private/path_manager.h
+++ b/include/mptcpd/private/path_manager.h
@@ -138,19 +138,24 @@ struct mptcpd_pm_cmd_ops
         /**
          * @brief Advertise new network address to peers.
          *
-         * @param[in] pm    The mptcpd path manager object.
-         * @param[in] addr  Local IP address and port to be advertised
-         *                  through the MPTCP protocol @c ADD_ADDR
-         *                  option.  The port is optional, and is
-         *                  ignored if it is zero.
-         * @param[in] id    MPTCP local address ID.
-         * @param[in] token MPTCP connection token.
+         * @param[in]     pm    The mptcpd path manager object.
+         * @param[in,out] addr  Local IP address and port to be
+         *                      advertised through the MPTCP protocol
+         *                      @c ADD_ADDR option.  If the port is
+         *                      zero an ephemeral port will be chosen,
+         *                      and assigned to the appropriate
+         *                      underlying address family-specific
+         *                      port member, e.g. @c sin_port or
+         *                      @c sin6_port.  The port will be in
+         *                      network byte order.
+         * @param[in]     id    MPTCP local address ID.
+         * @param[in]     token MPTCP connection token.
          *
          * @return @c 0 if operation was successful. -1 or @c errno
          *         otherwise.
          */
         int (*add_addr)(struct mptcpd_pm *pm,
-                        struct sockaddr const *addr,
+                        struct sockaddr *addr,
                         mptcpd_aid_t id,
                         mptcpd_token_t token);
 
@@ -158,9 +163,8 @@ struct mptcpd_pm_cmd_ops
          * @brief Stop advertising network address to peers.
          *
          * @param[in] pm    The mptcpd path manager object.
-         * @param[in] addr  Local IP address and port (zero if unused)
-         *                  that should no longer be advertised
-         *                  through MPTCP.
+         * @param[in] addr  Local IP address and port that should no
+         *                  longer be advertised through MPTCP.
          * @param[in] id    MPTCP local address ID.
          * @param[in] token MPTCP connection token.
          *

--- a/include/mptcpd/private/plugin.h
+++ b/include/mptcpd/private/plugin.h
@@ -4,7 +4,7 @@
  *
  * @brief mptcpd private plugin interface.
  *
- * Copyright (c) 2017-2021, Intel Corporation
+ * Copyright (c) 2017-2022, Intel Corporation
  */
 
 #ifndef MPTCPD_PRIVATE_PLUGIN_H
@@ -55,31 +55,35 @@ MPTCPD_API void mptcpd_plugin_unload(struct mptcpd_pm *pm);
 /**
  * @brief Notify plugin of new MPTCP connection pending completion.
  *
- * @param[in] name   Plugin name.
- * @param[in] token  MPTCP connection token.
- * @param[in] laddr  Local address information.
- * @param[in] raddr  Remote address information.
- * @param[in] pm     Opaque pointer to mptcpd path manager object.
+ * @param[in] name        Plugin name.
+ * @param[in] token       MPTCP connection token.
+ * @param[in] laddr       Local address information.
+ * @param[in] raddr       Remote address information.
+ * @param[in] server_side Server side connection flag.
+ * @param[in] pm          Opaque pointer to mptcpd path manager object.
  */
 MPTCPD_API void mptcpd_plugin_new_connection(
         char const *name,
         mptcpd_token_t token,
         struct sockaddr const *laddr,
         struct sockaddr const *raddr,
+        bool server_side,
         struct mptcpd_pm *pm);
 
 /**
  * @brief Notify plugin of MPTCP connection completion.
  *
- * @param[in] token  MPTCP connection token.
- * @param[in] laddr  Local address information.
- * @param[in] raddr  Remote address information.
- * @param[in] pm     Opaque pointer to mptcpd path manager object.
+ * @param[in] token       MPTCP connection token.
+ * @param[in] laddr       Local address information.
+ * @param[in] raddr       Remote address information.
+ * @param[in] server_side Server side connection flag.
+ * @param[in] pm          Opaque pointer to mptcpd path manager object.
  */
 MPTCPD_API void mptcpd_plugin_connection_established(
         mptcpd_token_t token,
         struct sockaddr const *laddr,
         struct sockaddr const *raddr,
+        bool server_side,
         struct mptcpd_pm *pm);
 
 /**

--- a/include/mptcpd/private/sockaddr.h
+++ b/include/mptcpd/private/sockaddr.h
@@ -64,6 +64,22 @@ mptcpd_sockaddr_storage_init(in_addr_t const *addr4,
                              in_port_t port,
                              struct sockaddr_storage *addr);
 
+/**
+ * @brief Deep copy a @c sockaddr.
+ *
+ * Copy the address family-specific contents of a @c sockaddr.  For an
+ * @c AF_INET address family, a @c struct @c sockaddr_in will be
+ * dynamically allocated and copied from @a sa.  Similarly, @c struct
+ * @c sockaddr_in6 will be allocated and copied from @a sa for the
+ * @c AF_INET6 address family case.
+ *
+ * @return Dynamically allocated copy of @a sa if the @c sa_family
+ *         member is @c AF_INET or @c AF_INET6, and @c NULL otherwise.
+ *         Deallocate with @c l_free().
+ */
+MPTCPD_API struct sockaddr *
+mptcpd_sockaddr_copy(struct sockaddr const *sa);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -30,10 +30,6 @@ libmptcpd_la_SOURCES =		\
 	hash_sockaddr.c		\
 	hash_sockaddr.h
 
-#IF BUILDING_DLL
-#libmptcpd_la_SOURCES += debug.c
-#endif
-
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = mptcpd.pc
 

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -25,7 +25,9 @@ libmptcpd_la_SOURCES =		\
 	path_manager.c		\
 	plugin.c		\
 	sockaddr.c		\
-	murmur_hash.c
+	murmur_hash.c		\
+	hash_sockaddr.c		\
+	hash_sockaddr.h
 
 #if BUILDING_DLL
 #libmptcpd_la_SOURCES += debug.c

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -21,6 +21,7 @@ libmptcpd_la_LDFLAGS = 	\
 libmptcpd_la_SOURCES =		\
 	addr_info.c		\
 	id_manager.c		\
+	listener_manager.c	\
 	network_monitor.c	\
 	path_manager.c		\
 	plugin.c		\
@@ -29,7 +30,7 @@ libmptcpd_la_SOURCES =		\
 	hash_sockaddr.c		\
 	hash_sockaddr.h
 
-#if BUILDING_DLL
+#IF BUILDING_DLL
 #libmptcpd_la_SOURCES += debug.c
 #endif
 

--- a/lib/hash_sockaddr.c
+++ b/lib/hash_sockaddr.c
@@ -24,6 +24,9 @@ static inline unsigned int
 mptcpd_hash_sockaddr_in(struct sockaddr_in const *sa,
                         uint32_t seed)
 {
+        /**
+         * @todo The port should also be included in the hash.
+         */
         return mptcpd_murmur_hash3(&sa->sin_addr.s_addr,
                                    sizeof(sa->sin_addr.s_addr),
                                    seed);
@@ -33,6 +36,9 @@ static inline unsigned int
 mptcpd_hash_sockaddr_in6(struct sockaddr_in6 const *sa,
                          uint32_t seed)
 {
+        /**
+         * @todo The port should also be included in the hash.
+         */
         return mptcpd_murmur_hash3(sa->sin6_addr.s6_addr,
                                    sizeof(sa->sin6_addr.s6_addr),
                                    seed);

--- a/lib/hash_sockaddr.c
+++ b/lib/hash_sockaddr.c
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/**
+ * @file hash_sockaddr.c
+ *
+ * @brief @c struct @c sockaddr hash related functions.
+ *
+ * Copyright (c) 2022, Intel Corporation
+ */
+
+#include <netinet/in.h>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#include <ell/util.h>
+#pragma GCC diagnostic pop
+
+
+#include <mptcpd/private/murmur_hash.h>
+
+#include "hash_sockaddr.h"
+
+
+static inline unsigned int
+mptcpd_hash_sockaddr_in(struct sockaddr_in const *sa,
+                        uint32_t seed)
+{
+        return mptcpd_murmur_hash3(&sa->sin_addr.s_addr,
+                                   sizeof(sa->sin_addr.s_addr),
+                                   seed);
+}
+
+static inline unsigned int
+mptcpd_hash_sockaddr_in6(struct sockaddr_in6 const *sa,
+                         uint32_t seed)
+{
+        return mptcpd_murmur_hash3(sa->sin6_addr.s6_addr,
+                                   sizeof(sa->sin6_addr.s6_addr),
+                                   seed);
+}
+
+unsigned int mptcpd_hash_sockaddr(void const *p)
+{
+        struct mptcpd_hash_sockaddr_key const *const key = p;
+        struct sockaddr const *const sa = key->sa;
+
+        if (sa->sa_family == AF_INET) {
+                struct sockaddr_in const *sa4 =
+                        (struct sockaddr_in const *) sa;
+
+                return mptcpd_hash_sockaddr_in(sa4, key->seed);
+        } else {
+                struct sockaddr_in6 const *sa6 =
+                        (struct sockaddr_in6 const *) sa;
+
+                return mptcpd_hash_sockaddr_in6(sa6, key->seed);
+        }
+}
+
+int mptcpd_hash_sockaddr_compare(void const *a, void const *b)
+{
+        struct mptcpd_hash_sockaddr_key const *const lkey = a;
+        struct mptcpd_hash_sockaddr_key const *const rkey = b;
+
+        struct sockaddr const *const lsa = lkey->sa;
+        struct sockaddr const *const rsa = rkey->sa;
+
+        /**
+         * @todo Should we compare the other @c struct @c sockaddr_in
+         *       and @c struct @c sockaddr_in6 fields as well?
+         */
+
+        if (lsa->sa_family == rsa->sa_family) {
+                if (lsa->sa_family == AF_INET) {
+                        // IPv4
+                        struct sockaddr_in const *const lin =
+                                (struct sockaddr_in const *) lsa;
+
+                        struct sockaddr_in const *const rin =
+                                (struct sockaddr_in const *) rsa;
+
+                        uint32_t const lhs = lin->sin_addr.s_addr;
+                        uint32_t const rhs = rin->sin_addr.s_addr;
+
+                        return lhs < rhs ? -1 : (lhs > rhs ? 1 : 0);
+                } else {
+                        // IPv6
+                        struct sockaddr_in6 const *const lin =
+                                (struct sockaddr_in6 const *) lsa;
+
+                        struct sockaddr_in6 const *const rin =
+                                (struct sockaddr_in6 const *) rsa;
+
+                        uint8_t const *const lhs = lin->sin6_addr.s6_addr;
+                        uint8_t const *const rhs = rin->sin6_addr.s6_addr;
+
+                        return memcmp(lhs,
+                                      rhs,
+                                      sizeof(lin->sin6_addr.s6_addr));
+                }
+        } else if (lsa->sa_family == AF_INET) {
+                return 1;   // IPv4 > IPv6
+        } else {
+                return -1;  // IPv6 < IPv4
+        }
+}
+
+void *mptcpd_hash_sockaddr_key_copy(void const *p)
+{
+        struct mptcpd_hash_sockaddr_key const *const src = p;
+        struct mptcpd_hash_sockaddr_key *const key =
+                l_new(struct mptcpd_hash_sockaddr_key, 1);
+
+        struct sockaddr *sa = NULL;
+
+        if (src->sa->sa_family == AF_INET) {
+                sa = (struct sockaddr *) l_new(struct sockaddr_in, 1);
+
+                memcpy(sa, src->sa, sizeof(struct sockaddr_in));
+        } else {
+                sa = (struct sockaddr *) l_new(struct sockaddr_in6, 1);
+
+                memcpy(sa, src->sa, sizeof(struct sockaddr_in6));
+        }
+
+        key->sa = sa;
+        key->seed = src->seed;
+
+        return key;
+}
+
+void mptcpd_hash_sockaddr_key_free(void *p)
+{
+        if (p == NULL)
+                return;
+
+        struct mptcpd_hash_sockaddr_key *const key = p;
+
+        l_free((void *) key->sa);  // Cast "const" away.
+        l_free(key);
+}
+
+
+/*
+  Local Variables:
+  c-file-style: "linux"
+  End:
+*/

--- a/lib/hash_sockaddr.h
+++ b/lib/hash_sockaddr.h
@@ -47,18 +47,7 @@ struct mptcpd_hash_sockaddr_key
 };
 
 /**
- * @brief Generate a hash value based on a @c struct @c sockaddr.
- *
- * @param[in] p @c struct @c mptcpd_hash_sockaddr_key instance containing
- *              the IP address to be hashed.
- *
- * @return The hash value.
- */
-unsigned int mptcpd_hash_sockaddr(void const *p);
-
-
-/**
- * @brief Compare hash map keys based on IP address.
+ * @brief Compare hash map keys based on IP address alone.
  *
  * @param[in] a Pointer @c struct @c sockaddr (left hand side).
  * @param[in] b Pointer @c struct @c sockaddr (right hand side).
@@ -66,6 +55,8 @@ unsigned int mptcpd_hash_sockaddr(void const *p);
  * @return 0 if the IP addresses are equal, and -1 or 1 otherwise,
  *         depending on IP address family and comparisons of IP
  *         addresses of the same type.
+ *
+ * @note Ports are not compared.
  */
 int mptcpd_hash_sockaddr_compare(void const *a, void const *b);
 

--- a/lib/hash_sockaddr.h
+++ b/lib/hash_sockaddr.h
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/**
+ * @file hash_sockaddr.h
+ *
+ * @brief @c struct @c sockaddr hash related functions.
+ *
+ * Copyright (c) 2022, Intel Corporation
+ */
+
+#ifndef MPTCPD_HASH_SOCKADDR_H
+#define MPTCPD_HASH_SOCKADDR_H
+
+#include <stdint.h>
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct sockaddr;
+
+/**
+ * @name ELL Hash Functions For IP Addresses
+ *
+ * A set of types and functions for using an IP address through a
+ * @c struct @c sockaddr as the key for an ELL hashmap (@c struct
+ * @c l_hashmap).
+ *
+ * @note These functions are only used internally, and are not
+ *       exported from libmptcpd.
+ */
+///@{
+
+/**
+ * @brief Hash key information.
+ *
+ * Bundle the values needed to generate a hash value based on an IP
+ * address (@c struct @c sockaddr) using the MurmurHash3 algorithm.
+ */
+struct mptcpd_hash_sockaddr_key
+{
+        /// IP address to be hashed.
+        struct sockaddr const *sa;
+
+        /// Hash algorithm (MurmurHash3) seed.
+        uint32_t seed;
+};
+
+/**
+ * @brief Generate a hash value based on a @c struct @c sockaddr.
+ *
+ * @param[in] p @c struct @c mptcpd_hash_sockaddr_key instance containing
+ *              the IP address to be hashed.
+ *
+ * @return The hash value.
+ */
+unsigned int mptcpd_hash_sockaddr(void const *p);
+
+
+/**
+ * @brief Compare hash map keys based on IP address.
+ *
+ * @param[in] a Pointer @c struct @c sockaddr (left hand side).
+ * @param[in] b Pointer @c struct @c sockaddr (right hand side).
+ *
+ * @return 0 if the IP addresses are equal, and -1 or 1 otherwise,
+ *         depending on IP address family and comparisons of IP
+ *         addresses of the same type.
+ */
+int mptcpd_hash_sockaddr_compare(void const *a, void const *b);
+
+/**
+ * @brief Deep copy the hash map key @a p.
+ *
+ * @return The dynamically allocated deep copy of the hash map key
+ *         @a p.  Deallocate with @c l_free().
+ */
+void *mptcpd_hash_sockaddr_key_copy(void const *p);
+
+/// Deallocate @struct @c mptcpd_hash_sockaddr_key instance.
+void mptcpd_hash_sockaddr_key_free(void *p);
+///@}
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif // MPTCPD_HASH_SOCKADDR_H
+
+/*
+  Local Variables:
+  c-file-style: "linux"
+  End:
+*/

--- a/lib/hash_sockaddr.h
+++ b/lib/hash_sockaddr.h
@@ -30,7 +30,6 @@ struct sockaddr;
  *       exported from libmptcpd.
  */
 ///@{
-
 /**
  * @brief Hash key information.
  *

--- a/lib/id_manager.c
+++ b/lib/id_manager.c
@@ -17,7 +17,6 @@
 #include <errno.h>
 #include <stdint.h>
 #include <string.h>
-#include <time.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 
@@ -34,6 +33,8 @@
 #include <mptcpd/private/id_manager.h>
 #include <mptcpd/id_manager.h>
 
+#include "hash_sockaddr.h"
+
 /// Invalid MPTCP address ID.
 #define MPTCPD_INVALID_ID 0
 
@@ -42,27 +43,6 @@
 
 /// Maximum MPTCP address ID.
 #define MPTCPD_MAX_ID UINT8_MAX
-
-
-/**
- * @brief MurmurHash3 seed value.
- *
- * @note This could be tied to each @c mptcpd_idm instance so that the
- *       seed value wouldn't shared between multiple mptcpd_idm
- *       instances but the only way to pass the seed value to the
- *       mptcpd MurmurHash3 hash function through the ELL @c l_hashmap
- *       interface would be to make it a part of the key, such as
- *       through a convenience @c struct.  That would double the size
- *       of the key on 64 bit platforms (sizeof(struct sockaddr*) +
- *       sizeof(uint32_t) + padding).  That may not be a problem for
- *       the common case since most platforms would not have many
- *       local addresses, meaning the larger key size would not impact
- *       the run-time memory footprint by much.  Furthermore, it is
- *       unlikely that such a global seed value shared between
- *       @c mptcpd_idm instances would be a problem since each
- *       @c mptcpd_idm insance would have its own @c l_hashmap.
- */
-static uint32_t _idm_hash_seed = 0;
 
 /**
  * @struct mptcpd_idm
@@ -84,99 +64,10 @@ struct mptcpd_idm
          *       array should perform just as well.
          */
         struct l_hashmap *map;
+
+        /// MurmurHash3 seed value.
+        uint32_t seed;
 };
-
-// ----------------------------------------------------------------------
-
-static inline unsigned int
-mptcpd_hash_sockaddr_in(struct sockaddr_in const *sa)
-{
-        return mptcpd_murmur_hash3(&sa->sin_addr.s_addr,
-                                   sizeof(sa->sin_addr.s_addr),
-                                   _idm_hash_seed);
-}
-
-static inline unsigned int
-mptcpd_hash_sockaddr_in6(struct sockaddr_in6 const *sa)
-{
-        return mptcpd_murmur_hash3(sa->sin6_addr.s6_addr,
-                                   sizeof(sa->sin6_addr.s6_addr),
-                                   _idm_hash_seed);
-}
-
-static unsigned int mptcpd_hash_sockaddr(void const *p)
-{
-        struct sockaddr const *const sa = p;
-        if (sa->sa_family == AF_INET) {
-                struct sockaddr_in const *sa4 =
-                        (struct sockaddr_in const *) sa;
-
-                return mptcpd_hash_sockaddr_in(sa4);
-        } else {
-                struct sockaddr_in6 const *sa6 =
-                        (struct sockaddr_in6 const *) sa;
-
-                return mptcpd_hash_sockaddr_in6(sa6);
-        }
-}
-
-static int mptcpd_hashmap_compare(void const *a, void const *b)
-{
-        struct sockaddr const *const lsa = a;
-        struct sockaddr const *const rsa = b;
-
-        if (lsa->sa_family == rsa->sa_family) {
-                if (lsa->sa_family == AF_INET) {
-                        // IPv4
-                        struct sockaddr_in const *const lin =
-                                (struct sockaddr_in const *) lsa;
-
-                        struct sockaddr_in const *const rin =
-                                (struct sockaddr_in const *) rsa;
-
-                        uint32_t const lhs = lin->sin_addr.s_addr;
-                        uint32_t const rhs = rin->sin_addr.s_addr;
-
-                        return lhs < rhs ? -1 : (lhs > rhs ? 1 : 0);
-                } else {
-                        // IPv6
-                        struct sockaddr_in6 const *const lin =
-                                (struct sockaddr_in6 const *) lsa;
-
-                        struct sockaddr_in6 const *const rin =
-                                (struct sockaddr_in6 const *) rsa;
-
-                        uint8_t const *const lhs = lin->sin6_addr.s6_addr;
-                        uint8_t const *const rhs = rin->sin6_addr.s6_addr;
-
-                        return memcmp(lhs,
-                                      rhs,
-                                      sizeof(lin->sin6_addr.s6_addr));
-                }
-        } else if (lsa->sa_family == AF_INET) {
-                return 1;   // IPv4 > IPv6
-        } else {
-                return -1;  // IPv6 < IPv4
-        }
-}
-
-static void *mptcpd_hashmap_key_copy(void const *p)
-{
-        struct sockaddr const *const sa = p;
-        struct sockaddr *key = NULL;
-
-        if (sa->sa_family == AF_INET) {
-                key = (struct sockaddr *) l_new(struct sockaddr_in, 1);
-
-                memcpy(key, sa, sizeof(struct sockaddr_in));
-        } else {
-                key = (struct sockaddr *) l_new(struct sockaddr_in6, 1);
-
-                memcpy(key, sa, sizeof(struct sockaddr_in6));
-        }
-
-        return key;
-}
 
 // ----------------------------------------------------------------------
 
@@ -211,16 +102,16 @@ struct mptcpd_idm *mptcpd_idm_create(void)
 
         if (!l_hashmap_set_hash_function(idm->map, mptcpd_hash_sockaddr)
             || !l_hashmap_set_compare_function(idm->map,
-                                               mptcpd_hashmap_compare)
+                                               mptcpd_hash_sockaddr_compare)
             || !l_hashmap_set_key_copy_function(idm->map,
-						mptcpd_hashmap_key_copy)
-            || !l_hashmap_set_key_free_function(idm->map, l_free)) {
+						mptcpd_hash_sockaddr_key_copy)
+            || !l_hashmap_set_key_free_function(idm->map,
+                                                mptcpd_hash_sockaddr_key_free)) {
                 mptcpd_idm_destroy(idm);
                 idm = NULL;
         }
 
-        if (_idm_hash_seed == 0)
-                _idm_hash_seed = l_getrandom_uint32();
+        idm->seed = l_getrandom_uint32();
 
         return idm;
 }
@@ -250,8 +141,12 @@ bool mptcpd_idm_map_id(struct mptcpd_idm *idm,
             || !l_uintset_put(idm->ids, id))
                 return false;
 
+        struct mptcpd_hash_sockaddr_key const key = {
+                .sa = sa, .seed = idm->seed
+        };
+
         if (!mptcpd_hashmap_replace(idm->map,
-                                    sa,
+                                    &key,
                                     L_UINT_TO_PTR(id),
                                     NULL)) {
                 (void) l_uintset_take(idm->ids, id);
@@ -268,8 +163,12 @@ mptcpd_aid_t mptcpd_idm_get_id(struct mptcpd_idm *idm,
         if (idm == NULL || sa == NULL)
                 return MPTCPD_INVALID_ID;
 
+        struct mptcpd_hash_sockaddr_key const key = {
+                .sa = sa, .seed = idm->seed
+        };
+
         // Check if an addr/ID mapping exists.
-        uint32_t id = L_PTR_TO_UINT(l_hashmap_lookup(idm->map, sa));
+        uint32_t id = L_PTR_TO_UINT(l_hashmap_lookup(idm->map, &key));
 
         if (id != MPTCPD_INVALID_ID)
                 return (mptcpd_aid_t) id;
@@ -292,8 +191,12 @@ mptcpd_aid_t mptcpd_idm_remove_id(struct mptcpd_idm *idm,
         if (idm == NULL || sa == NULL)
                 return MPTCPD_INVALID_ID;
 
+        struct mptcpd_hash_sockaddr_key const key = {
+                .sa = sa, .seed = idm->seed
+        };
+
         mptcpd_aid_t const id =
-                L_PTR_TO_UINT(l_hashmap_remove(idm->map, sa));
+                L_PTR_TO_UINT(l_hashmap_remove(idm->map, &key));
 
         if (id == 0 || !l_uintset_take(idm->ids, id))
                 return MPTCPD_INVALID_ID;

--- a/lib/id_manager.c
+++ b/lib/id_manager.c
@@ -97,8 +97,8 @@ struct mptcpd_idm *mptcpd_idm_create(void)
         assert(MPTCPD_MIN_ID != MPTCPD_INVALID_ID);
 
         idm->ids = l_uintset_new_from_range(MPTCPD_MIN_ID, MPTCPD_MAX_ID);
-
         idm->map = l_hashmap_new();
+        idm->seed = l_getrandom_uint32();
 
         if (!l_hashmap_set_hash_function(idm->map, mptcpd_hash_sockaddr)
             || !l_hashmap_set_compare_function(idm->map,
@@ -110,8 +110,6 @@ struct mptcpd_idm *mptcpd_idm_create(void)
                 mptcpd_idm_destroy(idm);
                 idm = NULL;
         }
-
-        idm->seed = l_getrandom_uint32();
 
         return idm;
 }

--- a/lib/listener_manager.c
+++ b/lib/listener_manager.c
@@ -28,6 +28,7 @@
 #pragma GCC diagnostic pop
 
 #include <mptcpd/private/murmur_hash.h>
+#include <mptcpd/private/listener_manager.h>
 #include <mptcpd/listener_manager.h>
 
 #include "hash_sockaddr.h"

--- a/lib/listener_manager.c
+++ b/lib/listener_manager.c
@@ -33,6 +33,10 @@
 
 #include "hash_sockaddr.h"
 
+#ifndef IPPROTO_MPTCP
+#define IPPROTO_MPTCP IPPROTO_TCP + 256
+#endif
+
 
 // ----------------------------------------------------------------------
 
@@ -261,10 +265,6 @@ static bool is_unbound_address(struct sockaddr const *sa)
 
 static int open_listener(struct sockaddr const *sa)
 {
-#ifndef IPPROTO_MPTCP
-#define IPPROTO_MPTCP IPPROTO_TCP + 256
-#endif
-
         int const fd = socket(sa->sa_family, SOCK_STREAM, IPPROTO_MPTCP);
         if (fd == -1) {
                 l_error("Unable to open MPTCP listener: %s",

--- a/lib/listener_manager.c
+++ b/lib/listener_manager.c
@@ -26,7 +26,7 @@
 #include <ell/log.h>
 #pragma GCC diagnostic pop
 
-#include "listener_manager.h"
+#include <mptcpd/listener_manager.h>
 
 
 // ----------------------------------------------------------------------

--- a/lib/listener_manager.c
+++ b/lib/listener_manager.c
@@ -105,7 +105,7 @@ struct key_in
  * struct endpoint_in6 endpoint = {
  *     .addr = { .s6_addr = { [0]  = 0x20,
  *                            [1]  = 0x01,
- *                            [2]  = 0X0D,
+ *                            [2]  = 0x0D,
  *                            [3]  = 0xB8,
  *                            [14] = 0x01,
  *                            [15] = 0x02 } },

--- a/lib/path_manager.c
+++ b/lib/path_manager.c
@@ -370,6 +370,11 @@ struct mptcpd_idm * mptcpd_pm_get_idm(struct mptcpd_pm const *pm)
         return pm->idm;
 }
 
+struct mptcpd_lm * mptcpd_pm_get_lm(struct mptcpd_pm const *pm)
+{
+        return pm->lm;
+}
+
 
 /*
   Local Variables:

--- a/lib/path_manager.c
+++ b/lib/path_manager.c
@@ -4,7 +4,7 @@
  *
  * @brief mptcpd generic netlink commands.
  *
- * Copyright (c) 2017-2021, Intel Corporation
+ * Copyright (c) 2017-2022, Intel Corporation
  */
 
 #ifdef HAVE_CONFIG_H
@@ -262,6 +262,7 @@ int mptcpd_pm_add_addr(struct mptcpd_pm *pm,
 }
 
 int mptcpd_pm_remove_addr(struct mptcpd_pm *pm,
+                          struct sockaddr const *addr,
                           mptcpd_aid_t address_id,
                           mptcpd_token_t token)
 {
@@ -277,7 +278,7 @@ int mptcpd_pm_remove_addr(struct mptcpd_pm *pm,
         if (ops == NULL || ops->remove_addr == NULL)
                 return ENOTSUP;
 
-        return ops->remove_addr(pm, address_id, token);
+        return ops->remove_addr(pm, addr, address_id, token);
 }
 
 int mptcpd_pm_add_subflow(struct mptcpd_pm *pm,

--- a/lib/path_manager.c
+++ b/lib/path_manager.c
@@ -239,7 +239,7 @@ int mptcpd_kpm_set_flags(struct mptcpd_pm *pm,
 // -------------------------------------------------------------------
 
 int mptcpd_pm_add_addr(struct mptcpd_pm *pm,
-                       struct sockaddr const *addr,
+                       struct sockaddr *addr,
                        mptcpd_aid_t address_id,
                        mptcpd_token_t token)
 {

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -4,7 +4,7 @@
  *
  * @brief Common path manager plugin functions.
  *
- * Copyright (c) 2018-2021, Intel Corporation
+ * Copyright (c) 2018-2022, Intel Corporation
  */
 
 #ifdef HAVE_CONFIG_H
@@ -580,6 +580,7 @@ void mptcpd_plugin_new_connection(char const *name,
                                   mptcpd_token_t token,
                                   struct sockaddr const *laddr,
                                   struct sockaddr const *raddr,
+                                  bool server_side,
                                   struct mptcpd_pm *pm)
 {
         struct mptcpd_plugin_ops const *const ops = name_to_ops(name);
@@ -591,18 +592,23 @@ void mptcpd_plugin_new_connection(char const *name,
                 l_error("Unable to map connection to plugin.");
 
         if (ops && ops->new_connection)
-                ops->new_connection(token, laddr, raddr, pm);
+                ops->new_connection(token, laddr, raddr, server_side, pm);
 }
 
 void mptcpd_plugin_connection_established(mptcpd_token_t token,
                                           struct sockaddr const *laddr,
                                           struct sockaddr const *raddr,
+                                          bool server_side,
                                           struct mptcpd_pm *pm)
 {
         struct mptcpd_plugin_ops const *const ops = token_to_ops(token);
 
         if (ops && ops->connection_established)
-                ops->connection_established(token, laddr, raddr, pm);
+                ops->connection_established(token,
+                                            laddr,
+                                            raddr,
+                                            server_side,
+                                            pm);
 }
 
 void mptcpd_plugin_connection_closed(mptcpd_token_t token,

--- a/lib/sockaddr.c
+++ b/lib/sockaddr.c
@@ -11,6 +11,11 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#include <ell/util.h>
+#pragma GCC diagnostic pop
+
 #include <mptcpd/private/sockaddr.h>
 
 
@@ -39,6 +44,21 @@ bool mptcpd_sockaddr_storage_init(in_addr_t const *addr4,
         }
 
         return true;
+}
+
+struct sockaddr *
+mptcpd_sockaddr_copy(struct sockaddr const *sa)
+{
+        if (sa == NULL)
+                return NULL;
+
+        if (sa->sa_family == AF_INET)
+                return l_memdup(sa, sizeof(struct sockaddr_in));
+        else if (sa->sa_family == AF_INET6)
+                return l_memdup(sa, sizeof(struct sockaddr_in6));
+
+        // Not an IPv4 or IPv6 address.
+        return NULL;
 }
 
 

--- a/m4/mptcpd_kernel.m4
+++ b/m4/mptcpd_kernel.m4
@@ -39,16 +39,16 @@ AC_DEFUN([MPTCPD_CHECK_KERNEL_HEADER_UPSTREAM],
              [Define to 1 if you have the upstream kernel
              <linux/mptcp.h> header.])
 
- AC_CACHE_CHECK([for MPTCP_PM_CMD_ANNOUNCE in linux/mptcp.h],
+ AC_CACHE_CHECK([for MPTCP_ATTR_SERVER_SIDE in linux/mptcp.h],
    [mptcpd_cv_header_upstream],
    [
-    # Perform a compile-time test since MPTCP_PM_CMD_ANNOUNCE is an
+    # Perform a compile-time test since MPTCP_ATTR_SERVER_SIDE is an
     # enumerator, not a preprocessor symbol.
     AC_COMPILE_IFELSE([
       AC_LANG_SOURCE([
 #include <linux/mptcp.h>
 
-int announce_cmd(void) { return MPTCP_PM_CMD_ANNOUNCE; }
+int get_mptcp_attr(void) { return (int) MPTCP_ATTR_SERVER_SIDE; }
       ])
     ],
     [mptcpd_cv_header_upstream=yes],

--- a/plugins/path_managers/sspi.c
+++ b/plugins/path_managers/sspi.c
@@ -4,7 +4,7 @@
  *
  * @brief MPTCP single-subflow-per-interface path manager plugin.
  *
- * Copyright (c) 2018-2021, Intel Corporation
+ * Copyright (c) 2018-2022, Intel Corporation
  */
 
 #ifdef HAVE_CONFIG_H
@@ -543,9 +543,11 @@ static void sspi_send_addrs(struct mptcpd_interface const *i, void *data)
 static void sspi_new_connection(mptcpd_token_t token,
                                 struct sockaddr const *laddr,
                                 struct sockaddr const *raddr,
+                                bool server_side,
                                 struct mptcpd_pm *pm)
 {
         (void) raddr;
+        (void) server_side;
 
         /**
          * @note Because we directly store connection tokens in a
@@ -603,11 +605,13 @@ static void sspi_new_connection(mptcpd_token_t token,
 static void sspi_connection_established(mptcpd_token_t token,
                                         struct sockaddr const *laddr,
                                         struct sockaddr const *raddr,
+                                        bool server_side,
                                         struct mptcpd_pm *pm)
 {
         (void) token;
         (void) laddr;
         (void) raddr;
+        (void) server_side,
         (void) pm;
 
         /**

--- a/plugins/path_managers/sspi.c
+++ b/plugins/path_managers/sspi.c
@@ -27,6 +27,7 @@
 #include <mptcpd/network_monitor.h>
 #include <mptcpd/path_manager.h>
 #include <mptcpd/plugin.h>
+#include <mptcpd/private/sockaddr.h>
 
 /**
  * @brief Local address to interface mapping failure value.
@@ -459,8 +460,9 @@ static bool sspi_remove_token(void *data, void *user_data)
 /**
  * @brief Inform kernel of local address available for subflows.
  *
- * @param[in] i    Network interface information.
- * @param[in] data User supplied data, the path manager in this case.
+ * @param[in] data      @c struct @c sockaddr containing address to
+ *                      advertise.
+ * @param[in] user_data New connection information.
  */
 static void sspi_send_addr(void *data, void *user_data)
 {
@@ -475,24 +477,25 @@ static void sspi_send_addr(void *data, void *user_data)
          */
         mptcpd_aid_t address_id = 0;
 
-        /**
-         * @note The port is an optional field of the MPTCP
-         *       @c ADD_ADDR option.  Setting it to zero causes it to
-         *       be ignored when sending the address information to
-         *       the kernel.
-         */
         /*
-        in_port_t const port = 0;
-        if (addr->sa_family == AF_INET)
-                ((struct sockaddr_in const *) addr)->sin_port = port;
-        else
-                ((struct sockaddr_in6 const *) addr)->sin6_port = port;
-        */
+          mptcpd_pm_add_addr() will modify the sockaddr passed to it
+          if the port is zero.  Make a copy to avoid modifying the
+          original.
+         */
+        struct sockaddr *const sa = mptcpd_sockaddr_copy(addr);
 
         mptcpd_pm_add_addr(info->pm,
-                           addr,
+                           sa,
                            address_id,
                            info->token);
+
+        /**
+         * @todo The sspi plugin currently doesn't stop advertising IP
+         *       addresses.  The address will need to be stored for later
+         *       use in mptcpd_pm_remove_addr() once the need for that
+         *       occurs.
+         */
+        l_free(sa);
 }
 
 /**

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -20,9 +20,7 @@ libpath_manager_la_SOURCES =	\
 	netlink_pm.c		\
 	netlink_pm.h		\
 	path_manager.c		\
-	path_manager.h		\
-	listener_manager.c	\
-	listener_manager.h
+	path_manager.h
 
 if HAVE_UPSTREAM_KERNEL
 libpath_manager_la_SOURCES += netlink_pm_upstream.c

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -20,7 +20,9 @@ libpath_manager_la_SOURCES =	\
 	netlink_pm.c		\
 	netlink_pm.h		\
 	path_manager.c		\
-	path_manager.h
+	path_manager.h		\
+	listener_manager.c	\
+	listener_manager.h
 
 if HAVE_UPSTREAM_KERNEL
 libpath_manager_la_SOURCES += netlink_pm_upstream.c

--- a/src/commands.c
+++ b/src/commands.c
@@ -54,8 +54,7 @@ bool mptcpd_check_genl_error(struct l_genl_msg *msg, char const *fname)
         int const error = l_genl_msg_get_error(msg);
 
         if (error < 0) {
-                // Error during send.  Likely insufficient perms.
-
+                // Error during send.
                 char const *const genl_errmsg =
 #ifdef HAVE_L_GENL_MSG_GET_EXTENDED_ERROR
                         l_genl_msg_get_extended_error(msg);
@@ -63,18 +62,13 @@ bool mptcpd_check_genl_error(struct l_genl_msg *msg, char const *fname)
                         NULL;
 #endif
 
-                if (genl_errmsg != NULL) {
-                        l_error("%s: %s", fname, genl_errmsg);
-                } else {
-                        char errmsg[80];
-                        int const r = strerror_r(-error,
-                                                 errmsg,
-                                                 L_ARRAY_SIZE(errmsg));
+                char errmsg[80] = { 0 };
+                (void) strerror_r(-error, errmsg, L_ARRAY_SIZE(errmsg));
 
-                        l_error("%s error: %s",
-                                fname,
-                                r == 0 ? errmsg : "<unknown error>");
-                }
+                if (genl_errmsg != NULL)
+                        l_error("%s: %s: %s", fname, genl_errmsg, errmsg);
+                else
+                        l_error("%s: %s", fname, errmsg);
 
                 return false;
         }

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -340,7 +340,15 @@ static void set_plugins_to_load(struct mptcpd_config *config,
 // ---------------------------------------------------------------
 // Command line options
 // ---------------------------------------------------------------
-static char const doc[] = "Start the Multipath TCP daemon.";
+#ifdef HAVE_UPSTREAM_KERNEL
+#  define MPTCPD_KERNEL "upstream"
+#else
+#  define MPTCPD_KERNEL "multipath-tcp.org"
+#endif
+static char const doc[] =
+        "Start the Multipath TCP daemon."
+        "\v"
+        "Supported Linux kernel: " MPTCPD_KERNEL;
 
 /**
  * @name Command Line Option Key Values

--- a/src/listener_manager.c
+++ b/src/listener_manager.c
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/**
+ * @file listener_manager.c
+ *
+ * @brief Map of MPTCP local address ID to listener.
+ *
+ * Copyright (c) 2022, Intel Corporation
+ */
+
+#ifdef HAVE_CONFIG_H
+# include <mptcpd/private/config.h>
+#endif
+
+#include <assert.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#include <ell/hashmap.h>
+#include <ell/util.h>
+#include <ell/log.h>
+#pragma GCC diagnostic pop
+
+#include "listener_manager.h"
+
+
+// ----------------------------------------------------------------------
+
+struct l_hashmap *mptcpd_lm_create(void)
+{
+        // Map of MPTCP local address ID to MPTCP listener file
+        // descriptor.
+        return l_hashmap_new();
+}
+
+static void close_listener(void *value)
+{
+        /*
+          We don't need to worry about overflow due to casting from
+          unsigned int since the file descriptor value stored in the
+          map will never be larger than INT_MAX by design.
+        */
+        int const fd = L_PTR_TO_UINT(value);
+
+        (void) close(fd);
+}
+
+
+void mptcpd_lm_destroy(struct l_hashmap *lm)
+{
+        if (lm == NULL)
+                return;
+
+        l_hashmap_destroy(lm, close_listener);
+}
+
+bool mptcpd_lm_listen(struct l_hashmap *lm,
+                      mptcpd_aid_t id,
+                      struct sockaddr const *sa)
+{
+        /**
+         * @todo Allow id == 0?
+         */
+        if (lm == NULL || id == 0 || sa == NULL)
+                return false;
+
+        if (sa->sa_family != AF_INET && sa->sa_family != AF_INET6)
+                return false;
+
+#ifndef IPPROTO_MPTCP
+#define IPPROTO_MPTCP IPPROTO_TCP + 256
+#endif
+
+        int const fd = socket(sa->sa_family, SOCK_STREAM, IPPROTO_MPTCP);
+        if (fd == -1)
+                l_error("Unable to open MPTCP listener: %s",
+                        strerror(errno));
+
+        socklen_t const addr_size =
+                (sa->sa_family == AF_INET
+                 ? sizeof(struct sockaddr_in)
+                 : sizeof(struct sockaddr_in6));
+
+        if (bind(fd, sa, addr_size) == -1) {
+                l_error("Unable to bind MPTCP listener: %s",
+                        strerror(errno));
+                (void) close(fd);
+                return false;
+        }
+
+        if (listen(fd, 0) == -1) {
+                l_error("Unable to listen on MPTCP socket: %s",
+                        strerror(errno));
+                (void) close(fd);
+                return false;
+        }
+
+        if (!l_hashmap_insert(lm, L_UINT_TO_PTR(id), L_UINT_TO_PTR(fd))) {
+                l_error("Unable to map MPTCP address ID %u listener", id);
+                (void) close(fd);
+                return false;
+        }
+
+        return true;
+}
+
+bool mptcpd_lm_close(struct l_hashmap *lm, mptcpd_aid_t id)
+{
+        /**
+         * @todo Allow id == 0?
+         */
+        if (lm == NULL || id == 0)
+                return false;
+
+        void const *const value = l_hashmap_remove(lm, L_UINT_TO_PTR(id));
+
+        if (value == NULL) {
+                l_error("No listener for MPTCP address id %u.", id);
+                return false;
+        }
+
+        // Value will never exceed INT_MAX.
+        int const fd = L_PTR_TO_UINT(fd);
+
+        return close(fd) == 0;
+}
+
+
+/*
+  Local Variables:
+  c-file-style: "linux"
+  End:
+*/

--- a/src/listener_manager.c
+++ b/src/listener_manager.c
@@ -125,7 +125,7 @@ bool mptcpd_lm_close(struct l_hashmap *lm, mptcpd_aid_t id)
         }
 
         // Value will never exceed INT_MAX.
-        int const fd = L_PTR_TO_UINT(fd);
+        int const fd = L_PTR_TO_UINT(value);
 
         return close(fd) == 0;
 }

--- a/src/listener_manager.h
+++ b/src/listener_manager.h
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/**
+ * @file listener_manager.h
+ *
+ * @brief Map of MPTCP local address ID to listener.
+ *
+ * Copyright (c) 2022, Intel Corporation
+ */
+
+#ifndef MPTCPD_LISTENER_MANAGER_H
+#define MPTCPD_LISTENER_MANAGER_H
+
+#include <stdbool.h>
+
+#include <mptcpd/types.h>
+
+
+struct l_hashmap;
+struct sockaddr;
+
+/**
+ * @brief Create a MPTCP listener manager.
+ *
+ * @return Pointer to a MPTCP listener manager on success.  @c NULL on
+ *         failure.
+ */
+struct l_hashmap *mptcpd_lm_create(void);
+
+/**
+ * @brief Destroy MPTCP listener manager.
+ *
+ * @param[in,out] lm The mptcpd address listener manager object.
+ */
+void mptcpd_lm_destroy(struct l_hashmap *lm);
+
+/**
+ * @brief Listen on the given MPTCP local address.
+ *
+ * @param[in] lm The mptcpd address listener manager object.
+ * @param[in] id The MPTCP local address ID.
+ * @param[in] sa The MPTCP local address.
+ *
+ * @return @c true on success, and @c false on failure.
+ */
+bool mptcpd_lm_listen(struct l_hashmap *lm,
+                      mptcpd_aid_t id,
+                      struct sockaddr const *sa);
+
+/**
+ * @brief Stop listening on a MPTCP local address.
+ *
+ * @param[in] lm The mptcpd address listener manager object.
+ * @param[in] id The MPTCP local address ID.
+ *
+ * @return @c true on success, and @c false on failure.
+ */
+bool mptcpd_lm_close(struct l_hashmap *lm, mptcpd_aid_t id);
+
+#endif /* MPTCPD_LISTENER_MANAGER_H */
+
+
+/*
+  Local Variables:
+  c-file-style: "linux"
+  End:
+*/

--- a/src/netlink_pm_mptcp_org.c
+++ b/src/netlink_pm_mptcp_org.c
@@ -222,9 +222,12 @@ static int mptcp_org_add_addr(struct mptcpd_pm *pm,
 }
 
 static int mptcp_org_remove_addr(struct mptcpd_pm *pm,
+                                 struct sockaddr const *addr,
                                  mptcpd_aid_t address_id,
                                  mptcpd_token_t token)
 {
+        (void) addr;
+
         /*
           Payload:
               Token

--- a/src/netlink_pm_mptcp_org.c
+++ b/src/netlink_pm_mptcp_org.c
@@ -153,7 +153,7 @@ static bool append_remote_addr_attr(struct l_genl_msg *msg,
 // ---------------------------------------------------------------------
 
 static int mptcp_org_add_addr(struct mptcpd_pm *pm,
-                              struct sockaddr const *addr,
+                              struct sockaddr *addr,
                               mptcpd_aid_t id,
                               mptcpd_token_t token)
 {

--- a/src/netlink_pm_upstream.c
+++ b/src/netlink_pm_upstream.c
@@ -257,10 +257,21 @@ static int send_add_addr(struct mptcpd_pm *pm,
 //          User Space Path Manager Related Functions
 // --------------------------------------------------------------
 static int upstream_announce(struct mptcpd_pm *pm,
-                             struct sockaddr const *addr,
+                             struct sockaddr *addr,
                              mptcpd_aid_t id,
                              mptcpd_token_t token)
 {
+        /**
+         * Set up MPTCP listening socket.
+         *
+         * @note An ephemeral port will be assigned to the port in
+         *       @a addr if it is zero.
+         *
+         * @todo This should be optional.
+         */
+        if (!mptcpd_lm_listen(pm->lm, addr))
+                return -1;
+
         /**
          * @todo Add support for the optional network interface index
          *       attribute.
@@ -271,14 +282,6 @@ static int upstream_announce(struct mptcpd_pm *pm,
                 .flags    = MPTCP_PM_ADDR_FLAG_SIGNAL,
                 // .ifindex  = ...
         };
-
-        /**
-         * Set up MPTCP listening socket.
-         *
-         * @todo This should be optional.
-         */
-        if (mptcpd_lm_listen(pm->lm, addr) == 0)
-                return -1;
 
         return send_add_addr(pm,
                              MPTCP_PM_CMD_ANNOUNCE,

--- a/src/netlink_pm_upstream.c
+++ b/src/netlink_pm_upstream.c
@@ -22,13 +22,13 @@
 #include <ell/log.h>
 #pragma GCC diagnostic pop
 
-#include <mptcpd/private/mptcp_upstream.h>
+#include <mptcpd/types.h>
+#include <mptcpd/path_manager.h>
 #include <mptcpd/private/netlink_pm.h>
 #include <mptcpd/private/path_manager.h>
-#include <mptcpd/path_manager.h>
-#include <mptcpd/types.h>
 #include <mptcpd/private/addr_info.h>
 #include <mptcpd/private/sockaddr.h>
+#include <mptcpd/private/mptcp_upstream.h>
 
 #include "commands.h"
 #include "netlink_pm.h"

--- a/src/netlink_pm_upstream.c
+++ b/src/netlink_pm_upstream.c
@@ -277,7 +277,7 @@ static int upstream_announce(struct mptcpd_pm *pm,
          *
          * @todo This should be optional.
          */
-        if (!mptcpd_lm_listen(pm->lm, addr))
+        if (mptcpd_lm_listen(pm->lm, addr) == 0)
                 return -1;
 
         return send_add_addr(pm,

--- a/src/netlink_pm_upstream.c
+++ b/src/netlink_pm_upstream.c
@@ -277,7 +277,7 @@ static int upstream_announce(struct mptcpd_pm *pm,
          *
          * @todo This should be optional.
          */
-        if (!mptcpd_lm_listen(pm->lm, id, addr))
+        if (!mptcpd_lm_listen(pm->lm, addr))
                 return -1;
 
         return send_add_addr(pm,
@@ -289,8 +289,8 @@ static int upstream_announce(struct mptcpd_pm *pm,
 
 struct remove_info
 {
-        struct l_hashmap *const lm;
-        mptcpd_aid_t const id;
+        struct mptcpd_lm *const lm;
+        struct sockaddr const *const sa;
 };
 
 static void upstream_remove_callback(struct l_genl_msg *msg, void *user_data)
@@ -313,11 +313,12 @@ static void upstream_remove_callback(struct l_genl_msg *msg, void *user_data)
                  *
                  * @todo This should be optional.
                  */
-                (void) mptcpd_lm_close(info->lm, info->id);
+                (void) mptcpd_lm_close(info->lm, info->sa);
         }
 }
 
 static int upstream_remove(struct mptcpd_pm *pm,
+                           struct sockaddr const *addr,
                            mptcpd_aid_t id,
                            mptcpd_token_t token)
 {
@@ -357,7 +358,7 @@ static int upstream_remove(struct mptcpd_pm *pm,
                 return ENOMEM;
         }
 
-        struct remove_info info = { .lm = pm->lm, .id = id };
+        struct remove_info info = { .lm = pm->lm, .sa = addr };
 
         bool const result =
                 l_genl_family_send(pm->family,

--- a/src/netlink_pm_upstream.c
+++ b/src/netlink_pm_upstream.c
@@ -227,8 +227,10 @@ static int upstream_announce(struct mptcpd_pm *pm,
          *
          * @todo This should be optional.
          */
-        if (!mptcpd_lm_listen(pm->lm, addr))
-                return -1;
+        int const r = mptcpd_lm_listen(pm->lm, addr);
+
+        if (r != 0)
+                return r;
 
         /**
          * @todo Add support for the optional network interface index

--- a/src/netlink_pm_upstream.c
+++ b/src/netlink_pm_upstream.c
@@ -286,7 +286,8 @@ static int upstream_remove(struct mptcpd_pm *pm,
         /**
          * @todo Refactor upstream_remove() and
          *       mptcp_org_remove_addr() functions. They only differ
-         *       by command and attribute types.
+         *       by command and attribute types, and callback
+         *       function.
          */
 
         /*

--- a/src/netlink_pm_upstream.c
+++ b/src/netlink_pm_upstream.c
@@ -23,6 +23,7 @@
 #pragma GCC diagnostic pop
 
 #include <mptcpd/types.h>
+#include <mptcpd/listener_manager.h>
 #include <mptcpd/path_manager.h>
 #include <mptcpd/private/netlink_pm.h>
 #include <mptcpd/private/path_manager.h>
@@ -32,7 +33,6 @@
 
 #include "commands.h"
 #include "netlink_pm.h"
-#include "listener_manager.h"
 #include "path_manager.h"
 
 // Sanity check

--- a/src/netlink_pm_upstream.c
+++ b/src/netlink_pm_upstream.c
@@ -65,7 +65,7 @@
  *
  * @return @c true on success.  @c false otherwise.
  */
-static bool mptcpd_addr_info_init(struct in_addr  const *addr4,
+static bool mptcpd_addr_info_init(in_addr_t       const *addr4,
                                   struct in6_addr const *addr6,
                                   in_port_t       const *port,
                                   uint8_t         const *id,

--- a/src/path_manager.c
+++ b/src/path_manager.c
@@ -39,12 +39,12 @@
 #include <mptcpd/private/sockaddr.h>
 #include <mptcpd/private/configuration.h>
 #include <mptcpd/private/addr_info.h>
+#include <mptcpd/listener_manager.h>
 
 // For netlink events.  Same API applies to multipath-tcp.org kernel.
 #include <mptcpd/private/mptcp_upstream.h>
 
 #include "path_manager.h"
-#include "listener_manager.h"
 #include "netlink_pm.h"
 
 

--- a/src/path_manager.c
+++ b/src/path_manager.c
@@ -39,7 +39,7 @@
 #include <mptcpd/private/sockaddr.h>
 #include <mptcpd/private/configuration.h>
 #include <mptcpd/private/addr_info.h>
-#include <mptcpd/listener_manager.h>
+#include <mptcpd/private/listener_manager.h>
 
 // For netlink events.  Same API applies to multipath-tcp.org kernel.
 #include <mptcpd/private/mptcp_upstream.h>

--- a/src/path_manager.c
+++ b/src/path_manager.c
@@ -44,6 +44,7 @@
 #include <mptcpd/private/mptcp_upstream.h>
 
 #include "path_manager.h"
+#include "listener_manager.h"
 #include "netlink_pm.h"
 
 
@@ -888,6 +889,15 @@ struct mptcpd_pm *mptcpd_pm_create(struct mptcpd_config const *config)
                 return NULL;
         }
 
+        // Create mptcpd listener manager.
+        pm->lm = mptcpd_lm_create();
+
+        if (pm->lm == NULL) {
+                mptcpd_pm_destroy(pm);
+                l_error("Unable to create listener manager.");
+                return NULL;
+        }
+
         pm->event_ops = l_queue_new();
 
         return pm;
@@ -906,6 +916,7 @@ void mptcpd_pm_destroy(struct mptcpd_pm *pm)
         mptcpd_plugin_unload(pm);
 
         l_queue_destroy(pm->event_ops, l_free);
+        mptcpd_lm_destroy(pm->lm);
         mptcpd_idm_destroy(pm->idm);
         mptcpd_nm_destroy(pm->nm);
         l_timeout_remove(pm->timeout);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -105,7 +105,7 @@ test_id_manager_LDADD =				\
 
 test_listener_manager_SOURCES = test-listener-manager.c
 test_listener_manager_LDADD =			\
-	$(top_builddir)/src/libpath_manager.la	\
+	$(top_builddir)/lib/libmptcpd.la	\
 	$(ELL_LIBS)				\
 	$(CODE_COVERAGE_LIBS)
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -28,6 +28,7 @@ check_PROGRAMS =		\
 	test-commands		\
 	test-configuration	\
 	test-id-manager		\
+	test-listener-manager	\
 	test-sockaddr		\
 	test-addr-info		\
 	test-murmur-hash
@@ -99,6 +100,12 @@ test_configuration_LDADD =			\
 test_id_manager_SOURCES = test-id-manager.c
 test_id_manager_LDADD =				\
 	$(top_builddir)/lib/libmptcpd.la	\
+	$(ELL_LIBS)				\
+	$(CODE_COVERAGE_LIBS)
+
+test_listener_manager_SOURCES = test-listener-manager.c
+test_listener_manager_LDADD =			\
+	$(top_builddir)/src/libpath_manager.la	\
 	$(ELL_LIBS)				\
 	$(CODE_COVERAGE_LIBS)
 

--- a/tests/lib/call_plugin.c
+++ b/tests/lib/call_plugin.c
@@ -28,12 +28,14 @@ void call_plugin_ops(struct plugin_call_count const *count,
                                              args->token,
                                              args->laddr,
                                              args->raddr,
+                                             args->server_side,
                                              args->pm);
 
         for (int i = 0; i < count->connection_established; ++i)
                 mptcpd_plugin_connection_established(args->token,
                                                      args->laddr,
                                                      args->raddr,
+                                                     args->server_side,
                                                      args->pm);
 
         for (int i = 0; i < count->new_address; ++i)

--- a/tests/lib/test-plugin.h
+++ b/tests/lib/test-plugin.h
@@ -138,20 +138,24 @@ static struct plugin_call_count const test_count_4 = {
  * types of values they correspond to.
  */
 ///@{
-static mptcpd_token_t const test_token_1    = 0x12345678;
-static mptcpd_aid_t   const test_laddr_id_1 = 0x34;
-static mptcpd_aid_t   const test_raddr_id_1 = 0x56;
-static bool           const test_backup_1   = true;
+static mptcpd_token_t const test_token_1       = 0x12345678;
+static mptcpd_aid_t   const test_laddr_id_1    = 0x34;
+static mptcpd_aid_t   const test_raddr_id_1    = 0x56;
+static bool           const test_backup_1      = true;
+static bool           const test_server_side_1 = true;
 
-static mptcpd_token_t const test_token_2    = 0x23456789;
-static mptcpd_aid_t   const test_laddr_id_2 = 0x23;
-static mptcpd_aid_t   const test_raddr_id_2 = 0x45;
-static bool           const test_backup_2   = false;
 
-static mptcpd_token_t const test_token_4    = 0x34567890;
-static mptcpd_aid_t   const test_laddr_id_4 = 0x90;
-static mptcpd_aid_t   const test_raddr_id_4 = 0x01;
-static bool           const test_backup_4   = true;
+static mptcpd_token_t const test_token_2       = 0x23456789;
+static mptcpd_aid_t   const test_laddr_id_2    = 0x23;
+static mptcpd_aid_t   const test_raddr_id_2    = 0x45;
+static bool           const test_backup_2      = false;
+static bool           const test_server_side_2 = true;
+
+static mptcpd_token_t const test_token_4       = 0x34567890;
+static mptcpd_aid_t   const test_laddr_id_4    = 0x90;
+static mptcpd_aid_t   const test_raddr_id_4    = 0x01;
+static bool           const test_backup_4      = true;
+static bool           const test_server_side_4 = false;
 
 // For verifying that a plugin will not be dispatched.
 static mptcpd_token_t const test_bad_token  = 0xFFFFFFFF;
@@ -290,6 +294,9 @@ struct plugin_call_args
 
         /// MPTCP backup priority.
         bool backup;
+
+        /// Server side connection flag.
+        bool server_side;
 
         /// Mptcpd path manager object.
         struct mptcpd_pm *const pm;

--- a/tests/lib/test-plugin.h
+++ b/tests/lib/test-plugin.h
@@ -196,7 +196,7 @@ static struct sockaddr_in6 const test_laddr_2 = {
         .sin6_port   = MPTCPD_CONSTANT_HTONS(0x5678),
         .sin6_addr   = { .s6_addr = { [0]  = 0x20,
                                       [1]  = 0x01,
-                                      [2]  = 0X0D,
+                                      [2]  = 0x0D,
                                       [3]  = 0xB8,
                                       [14] = 0x01,
                                       [15] = 0x02 }  // 2001:DB8::102
@@ -224,7 +224,7 @@ static struct sockaddr_in6 const test_raddr_1 = {
         .sin6_port   = MPTCPD_CONSTANT_HTONS(0x3456),
         .sin6_addr   = { .s6_addr = { [0]  = 0x20,
                                       [1]  = 0x01,
-                                      [2]  = 0X0D,
+                                      [2]  = 0x0D,
                                       [3]  = 0xB8,
                                       [14] = 0x02,
                                       [15] = 0x01 }  // 2001:DB8::201

--- a/tests/plugins/noop/noop.c
+++ b/tests/plugins/noop/noop.c
@@ -4,7 +4,7 @@
  *
  * @brief MPTCP test plugin.
  *
- * Copyright (c) 2019-2021, Intel Corporation
+ * Copyright (c) 2019-2022, Intel Corporation
  */
 
 #pragma GCC diagnostic push
@@ -23,11 +23,13 @@
 static void plugin_noop_new_connection(mptcpd_token_t token,
                                        struct sockaddr const *laddr,
                                        struct sockaddr const *raddr,
+                                       bool server_side,
                                        struct mptcpd_pm *pm)
 {
         (void) token;
         (void) laddr;
         (void) raddr;
+        (void) server_side;
         (void) pm;
 }
 
@@ -35,11 +37,13 @@ static void plugin_noop_connection_established(
         mptcpd_token_t token,
         struct sockaddr const *laddr,
         struct sockaddr const *raddr,
+        bool server_side,
         struct mptcpd_pm *pm)
 {
         (void) token;
         (void) laddr;
         (void) raddr;
+        (void) server_side;
         (void) pm;
 }
 

--- a/tests/plugins/priority/one.c
+++ b/tests/plugins/priority/one.c
@@ -4,7 +4,7 @@
  *
  * @brief MPTCP test plugin.
  *
- * Copyright (c) 2019-2021, Intel Corporation
+ * Copyright (c) 2019-2022, Intel Corporation
  */
 
 #pragma GCC diagnostic push
@@ -40,6 +40,7 @@ static struct sockaddr const *const remote_addr =
 static void plugin_one_new_connection(mptcpd_token_t token,
                                       struct sockaddr const *laddr,
                                       struct sockaddr const *raddr,
+                                      bool server_side,
                                       struct mptcpd_pm *pm)
 {
         (void) pm;
@@ -49,6 +50,7 @@ static void plugin_one_new_connection(mptcpd_token_t token,
         assert(!sockaddr_is_equal(laddr, raddr));
         assert(sockaddr_is_equal(laddr, local_addr));
         assert(sockaddr_is_equal(raddr, remote_addr));
+        assert(server_side == test_server_side_1);
 
         ++call_count.new_connection;
 }
@@ -57,6 +59,7 @@ static void plugin_one_connection_established(
         mptcpd_token_t token,
         struct sockaddr const *laddr,
         struct sockaddr const *raddr,
+        bool server_side,
         struct mptcpd_pm *pm)
 {
         (void) pm;
@@ -66,6 +69,7 @@ static void plugin_one_connection_established(
         assert(!sockaddr_is_equal(laddr, raddr));
         assert(sockaddr_is_equal(laddr, local_addr));
         assert(sockaddr_is_equal(raddr, remote_addr));
+        assert(server_side == test_server_side_1);
 
         ++call_count.connection_established;
 }

--- a/tests/plugins/priority/two.c
+++ b/tests/plugins/priority/two.c
@@ -4,7 +4,7 @@
  *
  * @brief MPTCP test plugin.
  *
- * Copyright (c) 2019-2021, Intel Corporation
+ * Copyright (c) 2019-2022, Intel Corporation
  */
 
 #pragma GCC diagnostic push
@@ -40,6 +40,7 @@ static struct sockaddr const *const remote_addr =
 static void plugin_two_new_connection(mptcpd_token_t token,
                                       struct sockaddr const *laddr,
                                       struct sockaddr const *raddr,
+                                      bool server_side,
                                       struct mptcpd_pm *pm)
 {
         (void) pm;
@@ -49,6 +50,7 @@ static void plugin_two_new_connection(mptcpd_token_t token,
         assert(!sockaddr_is_equal(laddr, raddr));
         assert(sockaddr_is_equal(laddr, local_addr));
         assert(sockaddr_is_equal(raddr, remote_addr));
+        assert(server_side == test_server_side_2);
 
         ++call_count.new_connection;
 }
@@ -57,6 +59,7 @@ static void plugin_two_connection_established(
         mptcpd_token_t token,
         struct sockaddr const *laddr,
         struct sockaddr const *raddr,
+        bool server_side,
         struct mptcpd_pm *pm)
 {
         (void) pm;
@@ -66,6 +69,7 @@ static void plugin_two_connection_established(
         assert(!sockaddr_is_equal(laddr, raddr));
         assert(sockaddr_is_equal(laddr, local_addr));
         assert(sockaddr_is_equal(raddr, remote_addr));
+        assert(server_side == test_server_side_2);
 
         ++call_count.connection_established;
 }

--- a/tests/plugins/security/four.c
+++ b/tests/plugins/security/four.c
@@ -4,7 +4,7 @@
  *
  * @brief MPTCP test plugin.
  *
- * Copyright (c) 2019-2021, Intel Corporation
+ * Copyright (c) 2019-2022, Intel Corporation
  */
 
 #pragma GCC diagnostic push
@@ -32,13 +32,15 @@ static struct plugin_call_count call_count;
 // ----------------------------------------------------------------
 
 static void plugin_four_new_connection(mptcpd_token_t token,
-                                        struct sockaddr const *laddr,
-                                        struct sockaddr const *raddr,
-                                        struct mptcpd_pm *pm)
+                                       struct sockaddr const *laddr,
+                                       struct sockaddr const *raddr,
+                                       bool server_side,
+                                       struct mptcpd_pm *pm)
 {
         (void) token;
         (void) laddr;
         (void) raddr;
+        (void) server_side;
         (void) pm;
 
         ++call_count.new_connection;
@@ -48,11 +50,13 @@ static void plugin_four_connection_established(
         mptcpd_token_t token,
         struct sockaddr const *laddr,
         struct sockaddr const *raddr,
+        bool server_side,
         struct mptcpd_pm *pm)
 {
         (void) token;
         (void) laddr;
         (void) raddr;
+        (void) server_side;
         (void) pm;
 
         ++call_count.connection_established;

--- a/tests/plugins/security/three.c
+++ b/tests/plugins/security/three.c
@@ -4,7 +4,7 @@
  *
  * @brief MPTCP test plugin.
  *
- * Copyright (c) 2019-2021, Intel Corporation
+ * Copyright (c) 2019-2022, Intel Corporation
  */
 
 #pragma GCC diagnostic push
@@ -34,11 +34,13 @@ static struct plugin_call_count call_count;
 static void plugin_three_new_connection(mptcpd_token_t token,
                                         struct sockaddr const *laddr,
                                         struct sockaddr const *raddr,
+                                        bool server_side,
                                         struct mptcpd_pm *pm)
 {
         (void) token;
         (void) laddr;
         (void) raddr;
+        (void) server_side;
         (void) pm;
 
         ++call_count.new_connection;
@@ -48,11 +50,13 @@ static void plugin_three_connection_established(
         mptcpd_token_t token,
         struct sockaddr const *laddr,
         struct sockaddr const *raddr,
+        bool server_side,
         struct mptcpd_pm *pm)
 {
         (void) token;
         (void) laddr;
         (void) raddr;
+        (void) server_side;
         (void) pm;
 
         ++call_count.connection_established;

--- a/tests/test-commands.c
+++ b/tests/test-commands.c
@@ -44,30 +44,52 @@
 
 // -------------------------------------------------------------------
 
-struct test_info
+struct test_addr_info
 {
-        struct l_netlink *const rtnl;
-
-        // Address used for kernel add_addr and dump_addr calls.
-        struct sockaddr const *const addr;
+        // Test address.
+        struct sockaddr *const addr;
 
         // Network interface on which to bind the test address.
         int const ifindex;
 
-        // CIDR prefix
-        uint8_t const prefix;
+        // CIDR prefix length.
+        uint8_t const prefix_len;
 
-        // String form of the addr.
-        char const *const ip;
+        /**
+         * @brief String form of the addr.
+         *
+         * @note Long enough for both IPv4 and IPv6 addresses.
+         */
+        char ip[INET6_ADDRSTRLEN];
+
+        /// MPTCP connection used in user space PM calls.
+        mptcpd_token_t token;
+
+        // MPTCP address ID used for add_addr and dump_addr calls.
+        mptcpd_aid_t id;
+};
+
+struct test_info
+{
+        struct l_netlink *const rtnl;
+
+        /*
+          Address information for user space add_addr and remove_addr
+          calls.
+        */
+        struct test_addr_info u_addr;
+
+        /*
+          Address information for kernel add_addr and dump_addr
+          calls.
+        */
+        struct test_addr_info k_addr;
 
         // Mptcpd configuration.
         struct mptcpd_config *config;
 
         // Mptcpd path manager object.
         struct mptcpd_pm *pm;
-
-        // ID used for kernel add_addr and dump_addr calls.
-        mptcpd_aid_t id;
 
         // Number of times dump_addrs call was completed.
         int dump_addrs_complete_count;
@@ -77,15 +99,21 @@ struct test_info
 };
 
 // -------------------------------------------------------------------
+/*
+  Number of addresses to set up for test purposes (2, user space and
+  kernel space).
+*/
+static int const addrs_to_setup_count = 2;
 
-static struct sockaddr const *const laddr1 =
-        (struct sockaddr const *) &test_laddr_1;
+// Number of addresses set up for test purposes.
+static int addr_setup_count;
+
+// -------------------------------------------------------------------
+// Addresses used for user space PM subflow command tests.
+// -------------------------------------------------------------------
 
 static struct sockaddr const *const laddr2 =
         (struct sockaddr const *) &test_laddr_2;
-
-static struct sockaddr const *const raddr1 =
-        (struct sockaddr const *) &test_raddr_1;
 
 static struct sockaddr const *const raddr2 =
         (struct sockaddr const *) &test_raddr_2;
@@ -108,10 +136,48 @@ static struct mptcpd_limit const _limits[] = {
 
 // -------------------------------------------------------------------
 
+static void const *get_in_addr(struct sockaddr const *sa)
+{
+        if (sa->sa_family == AF_INET) {
+                struct sockaddr_in const *const addr =
+                        (struct sockaddr_in const *) sa;
+
+                return &addr->sin_addr;
+        } else if (sa->sa_family == AF_INET6) {
+                struct sockaddr_in6 const *const addr =
+                        (struct sockaddr_in6 const *) sa;
+
+                return &addr->sin6_addr;
+        }
+
+        return NULL;  // Not an internet address. Unlikely.
+}
+
+static void dump_addr(char const *description, struct sockaddr const *a)
+{
+        assert(a != NULL);
+
+        void const *src = get_in_addr(a);
+
+        char addrstr[INET6_ADDRSTRLEN];  // Long enough for both IPv4
+                                         // and IPv6 addresses.
+
+        assert(inet_ntop(a->sa_family, src, addrstr, sizeof(addrstr)));
+
+        in_port_t const port = mptcpd_get_port_number(a);
+
+        l_info("%s: %s:<0x%x (%u)>",
+               description,
+               addrstr,
+               port,
+               port);
+}
+
 static void get_addr_callback(struct mptcpd_addr_info const *info,
                               void *user_data)
 {
-        struct test_info *const tinfo = (struct test_info *) user_data;
+        struct test_info const *const tinfo = user_data;
+        struct test_addr_info const *const k_addr = &tinfo->k_addr;
 
         /**
          * @bug We could have a resource leak in the kernel here if
@@ -121,16 +187,23 @@ static void get_addr_callback(struct mptcpd_addr_info const *info,
          */
         assert(info != NULL);
 
-        assert(mptcpd_addr_info_get_id(info) == tinfo->id);
-        assert(mptcpd_addr_info_get_index(info) == tinfo->ifindex);
-        assert(sockaddr_is_equal(tinfo->addr,
+        l_info("=======================");
+        dump_addr("Address   to mptcpd_kpm_add_addr()",
+                  k_addr->addr);
+        dump_addr("Address from mptcpd_kpm_get_addr()",
+                  mptcpd_addr_info_get_addr(info));
+        l_info("=======================");
+
+        assert(mptcpd_addr_info_get_id(info) == k_addr->id);
+        assert(mptcpd_addr_info_get_index(info) == k_addr->ifindex);
+        assert(sockaddr_is_equal(k_addr->addr,
                                  mptcpd_addr_info_get_addr(info)));
 }
 
 static void dump_addrs_callback(struct mptcpd_addr_info const *info,
                                 void *user_data)
 {
-        struct test_info *const tinfo = (struct test_info *) user_data;
+        struct test_info const *const tinfo = user_data;
 
         /**
          * @bug We could have a resource leak in the kernel here if
@@ -140,18 +213,20 @@ static void dump_addrs_callback(struct mptcpd_addr_info const *info,
          */
         assert(info != NULL);
 
+        struct test_addr_info const *const k_addr = &tinfo->k_addr;
+
         // Other IDs unrelated to this test could already exist.
-        if (mptcpd_addr_info_get_id(info) != tinfo->id)
+        if (mptcpd_addr_info_get_id(info) != k_addr->id)
                 return;
 
-        assert(mptcpd_addr_info_get_index(info) == tinfo->ifindex);
-        assert(sockaddr_is_equal(tinfo->addr,
+        assert(mptcpd_addr_info_get_index(info) == k_addr->ifindex);
+        assert(sockaddr_is_equal(k_addr->addr,
                                  mptcpd_addr_info_get_addr(info)));
 }
 
 static void dump_addrs_complete(void *user_data)
 {
-        struct test_info *const info = (struct test_info *) user_data;
+        struct test_info *const info = user_data;
 
         info->dump_addrs_complete_count++;
 }
@@ -231,23 +306,27 @@ static void test_add_addr(void const *test_data)
         struct mptcpd_idm *const idm  = mptcpd_pm_get_idm(pm);
 
         // Client-oriented path manager.
+        struct test_addr_info const *const u_addr = &info->u_addr;
+
         int result = mptcpd_pm_add_addr(pm,
-                                        laddr1,
-                                        test_laddr_id_1,
-                                        test_token_1);
+                                        u_addr->addr,
+                                        u_addr->id,
+                                        u_addr->token);
 
         assert(result == 0 || result == ENOTSUP);
 
         // In-kernel (server-oriented) path manager.
-        info->id = mptcpd_idm_get_id(idm, info->addr);
+        struct test_addr_info *const k_addr = &info->k_addr;
+
+        k_addr->id = mptcpd_idm_get_id(idm, k_addr->addr);
 
         uint32_t flags = 0;
 
         result = mptcpd_kpm_add_addr(pm,
-                                     info->addr,
-                                     info->id,
+                                     k_addr->addr,
+                                     k_addr->id,
                                      flags,
-                                     info->ifindex);
+                                     k_addr->ifindex);
 
         assert(result == 0 || result == ENOTSUP);
 }
@@ -258,15 +337,19 @@ static void test_remove_addr(void const *test_data)
         struct mptcpd_pm *const pm   = info->pm;
 
         // Client-oriented path manager.
+        struct test_addr_info const *const u_addr = &info->u_addr;
+
         int result = mptcpd_pm_remove_addr(pm,
-                                           laddr1,
-                                           test_laddr_id_1,
-                                           test_token_1);
+                                           u_addr->addr,
+                                           u_addr->id,
+                                           u_addr->token);
 
         assert(result == 0 || result == ENOTSUP);
 
         // In-kernel (server-oriented) path manager.
-        result = mptcpd_kpm_remove_addr(pm, info->id);
+        struct test_addr_info const *const k_addr = &info->k_addr;
+
+        result = mptcpd_kpm_remove_addr(pm, k_addr->id);
 
         assert(result == 0 || result == ENOTSUP);
 }
@@ -278,7 +361,7 @@ static void test_get_addr(void const *test_data)
 
         int const result =
                 mptcpd_kpm_get_addr(pm,
-                                    info->id,
+                                    info->k_addr.id,
                                     get_addr_callback,
                                     info,
                                     NULL);
@@ -353,7 +436,8 @@ static void test_set_flags(void const *test_data)
 
         static mptcpd_flags_t const flags = MPTCPD_ADDR_FLAG_BACKUP;
 
-        int const result = mptcpd_kpm_set_flags(pm, info->addr, flags);
+        int const result =
+                mptcpd_kpm_set_flags(pm, info->k_addr.addr, flags);
 
         assert(result == 0 || result == ENOTSUP);
 }
@@ -380,10 +464,10 @@ void test_set_backup(void const *test_data)
         struct mptcpd_pm *const pm   = info->pm;
 
         int const result = mptcpd_pm_set_backup(pm,
-                                                test_token_1,
-                                                laddr1,
-                                                raddr1,
-                                                test_backup_1);
+                                                test_token_2,
+                                                laddr2,
+                                                raddr2,
+                                                !test_backup_2);
 
         assert(result == 0 || result == ENOTSUP);
 }
@@ -394,9 +478,9 @@ void test_remove_subflow(void const *test_data)
         struct mptcpd_pm *const pm   = info->pm;
 
         int const result = mptcpd_pm_remove_subflow(pm,
-                                                    test_token_1,
-                                                    laddr1,
-                                                    raddr1);
+                                                    test_token_2,
+                                                    laddr2,
+                                                    raddr2);
 
         assert(result == 0 || result == ENOTSUP);
 }
@@ -425,17 +509,15 @@ static void handle_rtm_newaddr(int errnum,
         assert(data == NULL);
         assert(len == 0);
 
+        (void) user_data;  // Pointer to struct test_info.
+
         if (errnum != 0) {
 
                 static int const status = 0;  // Do not exit on error.
 
-                struct test_info *const info = user_data;
-
                 error(status,
                       errnum,
-                      "bind of test address %s to interface %d failed",
-                      info->ip,
-                      info->ifindex);
+                      "bind of test address to interface failed");
         }
 }
 
@@ -456,7 +538,7 @@ static void handle_rtm_deladdr(int errnum,
         if (errnum != 0) {
                 static int const status = 0;  // Do not exit on error.
 
-                struct test_info *const info = user_data;
+                struct test_addr_info *const info = user_data;
 
                 error(status,
                       errnum,
@@ -525,44 +607,97 @@ static void setup_tests (void *user_data)
 
 static void complete_address_setup(void *user_data)
 {
-        // Run tests after address setup is complete.
-        bool const result = l_idle_oneshot(setup_tests, user_data, NULL);
-        assert(result);
+        if (++addr_setup_count == addrs_to_setup_count) {
+                // Run tests after address setup is complete.
+                bool const result =
+                        l_idle_oneshot(setup_tests, user_data, NULL);
+
+                assert(result);
+        }
 }
 
 static void complete_address_teardown(void *user_data)
 {
         (void) user_data;
 
-        l_main_quit();
+        if (--addr_setup_count == 0)
+                l_main_quit();
+}
+
+static void setup_test_address(struct test_info *data,
+                               struct test_addr_info *info)
+{
+        sa_family_t const sa_family = info->addr->sa_family;
+
+        int id = 0;
+
+        if (sa_family == AF_INET) {
+                id = l_rtnl_ifaddr4_add(data->rtnl,
+                                        info->ifindex,
+                                        info->prefix_len,
+                                        info->ip,
+                                        NULL, // broadcast
+                                        handle_rtm_newaddr,
+                                        data,
+                                        complete_address_setup);
+        } else if (sa_family == AF_INET6) {
+                id = l_rtnl_ifaddr6_add(data->rtnl,
+                                        info->ifindex,
+                                        info->prefix_len,
+                                        info->ip,
+                                        handle_rtm_newaddr,
+                                        data,
+                                        complete_address_setup);
+        }
+
+        assert(id != 0);
 }
 
 static void setup_test_addresses(struct test_info *info)
 {
-        int const id = l_rtnl_ifaddr4_add(info->rtnl,
-                                          info->ifindex,
-                                          info->prefix,
-                                          info->ip,
-                                          NULL, // broadcast
-                                          handle_rtm_newaddr,
-                                          info,
-                                          complete_address_setup);
+        // Address used for user space PM advertising tests.
+        setup_test_address(info, &info->u_addr);
+
+        // Address used for kernel space PM tests.
+        setup_test_address(info, &info->k_addr);
+}
+
+static void teardown_test_address(struct l_netlink *rtnl,
+                                  struct test_addr_info *info)
+{
+        sa_family_t const sa_family = info->addr->sa_family;
+
+        int id = 0;
+
+        if (sa_family == AF_INET) {
+                id = l_rtnl_ifaddr4_delete(rtnl,
+                                           info->ifindex,
+                                           info->prefix_len,
+                                           info->ip,
+                                           NULL, // broadcast
+                                           handle_rtm_deladdr,
+                                           info,
+                                           complete_address_teardown);
+        } else if (sa_family == AF_INET6) {
+                id = l_rtnl_ifaddr6_delete(rtnl,
+                                           info->ifindex,
+                                           info->prefix_len,
+                                           info->ip,
+                                           handle_rtm_deladdr,
+                                           info,
+                                           complete_address_teardown);
+        }
 
         assert(id != 0);
 }
 
 static void teardown_test_addresses(struct test_info *info)
 {
-        int const id = l_rtnl_ifaddr4_delete(info->rtnl,
-                                             info->ifindex,
-                                             info->prefix,
-                                             info->ip,
-                                             NULL, // broadcast
-                                             handle_rtm_deladdr,
-                                             info,
-                                             complete_address_teardown);
+        // Address used for user space PM advertising tests.
+        teardown_test_address(info->rtnl, &info->u_addr);
 
-        assert(id != 0);
+        // Address used for kernel space PM tests.
+        teardown_test_address(info->rtnl, &info->k_addr);
 }
 
 // -------------------------------------------------------------------
@@ -596,6 +731,12 @@ static void idle_callback(struct l_idle *idle, void *user_data)
                 teardown_test_addresses(user_data); // Done running tests.
 }
 
+static uint8_t get_prefix_len(struct sockaddr const *sa)
+{
+        // One IP address
+        return sa->sa_family == AF_INET ? 32 : 128;
+}
+
 // -------------------------------------------------------------------
 
 int main(void)
@@ -612,34 +753,38 @@ int main(void)
         struct l_netlink *const rtnl = l_netlink_new(NETLINK_ROUTE);
         assert(rtnl != NULL);
 
-        static struct sockaddr const *const sa = laddr1;
-
-        // Bind test IP address to loopback interface.
+        // Bind test IP addresses to loopback interface.
         static char const loopback[] = "lo";
 
-        char ip[INET6_ADDRSTRLEN] = { 0 };
-
-        uint8_t prefix = 0;
-        void const *src = NULL;
-
-        if (sa->sa_family == AF_INET) {
-                prefix = 32;   // One IPv4 address
-                src = &((struct sockaddr_in  const *) sa)->sin_addr;
-        } else {
-                prefix = 128;  // One IPv6 address
-                src = &((struct sockaddr_in6 const *) sa)->sin6_addr;
-        }
+        // Mutable sockaddr copies.
+        struct sockaddr_in laddr1 = test_laddr_1;
+        struct sockaddr_in laddr4 = test_laddr_4;
 
         struct test_info info = {
                 .rtnl    = rtnl,
-                .addr    = sa,
-                .ifindex = if_nametoindex(loopback),
-                .prefix  = prefix,
-                .ip      = inet_ntop(sa->sa_family,
-                                     src,
-                                     ip,
-                                     sizeof(ip))
+                .u_addr = {
+                        .addr        = (struct sockaddr *) &laddr4,
+                        .ifindex     = if_nametoindex(loopback),
+                        .prefix_len  = get_prefix_len(info.u_addr.addr),
+                        .token       = test_token_4,
+                        .id          = test_laddr_id_4
+                },
+                .k_addr = {
+                        .addr        = (struct sockaddr *) &laddr1,
+                        .ifindex     = if_nametoindex(loopback),
+                        .prefix_len  = get_prefix_len(info.k_addr.addr)
+                }
         };
+
+        inet_ntop(info.u_addr.addr->sa_family,
+                  get_in_addr(info.u_addr.addr),
+                  info.u_addr.ip,
+                  sizeof(info.u_addr.ip));
+
+        inet_ntop(info.k_addr.addr->sa_family,
+                  get_in_addr(info.k_addr.addr),
+                  info.k_addr.ip,
+                  sizeof(info.k_addr.ip));
 
         setup_test_addresses(&info);
 

--- a/tests/test-commands.c
+++ b/tests/test-commands.c
@@ -259,6 +259,7 @@ static void test_remove_addr(void const *test_data)
 
         // Client-oriented path manager.
         int result = mptcpd_pm_remove_addr(pm,
+                                           laddr1,
                                            test_laddr_id_1,
                                            test_token_1);
 

--- a/tests/test-commands.c
+++ b/tests/test-commands.c
@@ -438,7 +438,15 @@ static void test_add_addr_user(void const *test_data)
                                               u_addr->id,
                                               u_addr->token);
 
-        assert(result == 0 || result == ENOTSUP);
+        /*
+          EADDRNOTAVAIL error will generally occur if the test is run
+          without sufficient permissions to set up the test addresses
+          by associating them with a network interface.
+
+         */
+        assert(result == 0
+               || result == ENOTSUP
+               || result == EADDRNOTAVAIL);
 }
 
 static void test_remove_addr_user(void const *test_data)

--- a/tests/test-id-manager.c
+++ b/tests/test-id-manager.c
@@ -53,6 +53,12 @@ static void test_map_id(void const *test_data)
         assert(mptcpd_idm_map_id(_idm,
                                  (struct sockaddr *) &test_laddr_4,
                                  _updated_id));
+
+        // Attempt to map invalid (0) ID.
+        mptcpd_aid_t const invalid_id = 0;
+        assert(!mptcpd_idm_map_id(_idm,
+                                  (struct sockaddr *) &test_laddr_4,
+                                  invalid_id));
 }
 
 static void test_get_id(void const *test_data)

--- a/tests/test-id-manager.c
+++ b/tests/test-id-manager.c
@@ -69,6 +69,12 @@ static void test_get_id(void const *test_data)
                                    (struct sockaddr *) &test_laddr_1);
         assert(_id[0] != 0);
 
+        struct sockaddr_in laddr_1_diff_port = test_laddr_1;
+        laddr_1_diff_port.sin_port = test_laddr_1.sin_port + 1;
+        assert(mptcpd_idm_get_id(_idm,
+                                 (struct sockaddr *) &laddr_1_diff_port)
+               == _id[0]);
+
         _id[1] = mptcpd_idm_get_id(_idm,
                                    (struct sockaddr *) &test_laddr_2);
         assert(_id[1] != 0 && _id[1] != _id[0]);

--- a/tests/test-listener-manager.c
+++ b/tests/test-listener-manager.c
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/**
+ * @file test-listener-manager.c
+ *
+ * @brief mptcpd listener manager test.
+ *
+ * Copyright (c) 2022, Intel Corporation
+ */
+
+
+#include <arpa/inet.h>
+
+#include <ell/log.h>
+#include <ell/test.h>
+#include <ell/hashmap.h>
+
+#include "../src/listener_manager.h"
+
+#include "test-plugin.h"  // For test sockaddrs
+
+#undef NDEBUG
+#include <assert.h>
+
+
+static struct l_hashmap *_lm;
+static mptcpd_aid_t const _id = 245;
+
+static void test_create(void const *test_data)
+{
+        (void) test_data;
+
+        _lm = mptcpd_lm_create();
+
+        assert(_lm != NULL);
+}
+
+static void test_listen(void const *test_data)
+{
+        (void) test_data;
+
+        struct sockaddr_in addr = {
+            .sin_family = AF_INET,
+            .sin_addr   = { .s_addr = htonl(INADDR_LOOPBACK) }
+        };
+
+        struct sockaddr const *const sa =
+            (struct sockaddr const *) &addr;
+
+        assert(mptcpd_lm_listen(_lm, _id, sa));
+}
+
+static void test_close(void const *test_data)
+{
+        (void) test_data;
+
+        assert(mptcpd_lm_close(_lm, _id));
+}
+
+
+static void test_destroy(void const *test_data)
+{
+        (void) test_data;
+
+        mptcpd_lm_destroy(_lm);
+}
+
+int main(int argc, char *argv[])
+{
+        l_log_set_stderr();
+
+        l_test_init(&argc, &argv);
+
+        l_test_add("create listener manager",  test_create,    NULL);
+        l_test_add("listen",                   test_listen,    NULL);
+        l_test_add("close",                    test_close,     NULL);
+        l_test_add("destroy listener manager", test_destroy,   NULL);
+
+        return l_test_run();
+}
+
+
+/*
+  Local Variables:
+  c-file-style: "linux"
+  End:
+*/

--- a/tests/test-listener-manager.c
+++ b/tests/test-listener-manager.c
@@ -7,14 +7,16 @@
  * Copyright (c) 2022, Intel Corporation
  */
 
-
 #include <arpa/inet.h>
 #include <netinet/in.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <ell/util.h>
 #include <ell/log.h>
 #include <ell/test.h>
 #include <ell/hashmap.h>
+#pragma GCC diagnostic pop
 
 #include <mptcpd/private/listener_manager.h>
 #include <mptcpd/listener_manager.h>
@@ -96,7 +98,7 @@ static void test_listen(void const *test_data)
 
         in_port_t const original_port = get_port(sa);
 
-        assert(mptcpd_lm_listen(_lm, sa));
+        assert(mptcpd_lm_listen(_lm, sa) == 0);
 
         in_port_t port = get_port(sa);
 
@@ -114,7 +116,7 @@ static void test_listen_bad_address(void const *test_data)
 {
         struct sockaddr *const sa = (struct sockaddr *) test_data;
 
-        assert(!mptcpd_lm_listen(_lm, sa));
+        assert(mptcpd_lm_listen(_lm, sa) != 0);
 }
 
 static void test_close(void const *test_data)
@@ -124,9 +126,9 @@ static void test_close(void const *test_data)
         in_port_t const port = get_port(sa);
 
         if (port == 0)
-                assert(!mptcpd_lm_close(_lm, sa));
+                assert(mptcpd_lm_close(_lm, sa) != 0);
         else
-                assert(mptcpd_lm_close(_lm, sa));
+                assert(mptcpd_lm_close(_lm, sa) == 0);
 }
 
 static void test_destroy(void const *test_data)

--- a/tests/test-listener-manager.c
+++ b/tests/test-listener-manager.c
@@ -16,6 +16,7 @@
 #include <ell/test.h>
 #include <ell/hashmap.h>
 
+#include <mptcpd/private/listener_manager.h>
 #include <mptcpd/listener_manager.h>
 
 #include "test-plugin.h"  // For test sockaddrs

--- a/tests/test-listener-manager.c
+++ b/tests/test-listener-manager.c
@@ -37,7 +37,7 @@ struct ipv6_listen_case
 };
 
 /**
- * @brief Initialize test case to listed on IPv4 loopback address.
+ * @brief Initialize test case to listen on IPv4 loopback address.
  *
  * @param[in] port IP port to listen on.
  */
@@ -54,7 +54,7 @@ struct ipv6_listen_case
         }
 
 /**
- * @brief Initialize test case to listed on IPv6 loopback address.
+ * @brief Initialize test case to listen on IPv6 loopback address.
  *
  * @param[in] port IP port to listen on.
  */

--- a/tests/test-listener-manager.c
+++ b/tests/test-listener-manager.c
@@ -38,6 +38,11 @@ static void test_listen(void const *test_data)
 {
         (void) test_data;
 
+        /*
+          Listen on the loopback address since we need an address
+          backed by a network interface so that underlying bind() call
+          can succeed.
+        */
         struct sockaddr_in addr = {
             .sin_family = AF_INET,
             .sin_addr   = { .s_addr = htonl(INADDR_LOOPBACK) }

--- a/tests/test-listener-manager.c
+++ b/tests/test-listener-manager.c
@@ -16,7 +16,6 @@
 #include <ell/util.h>
 #include <ell/log.h>
 #include <ell/test.h>
-#include <ell/hashmap.h>
 #pragma GCC diagnostic pop
 
 #include <mptcpd/private/listener_manager.h>

--- a/tests/test-listener-manager.c
+++ b/tests/test-listener-manager.c
@@ -9,7 +9,9 @@
 
 
 #include <arpa/inet.h>
+#include <netinet/in.h>
 
+#include <ell/util.h>
 #include <ell/log.h>
 #include <ell/test.h>
 #include <ell/hashmap.h>
@@ -21,6 +23,52 @@
 #undef NDEBUG
 #include <assert.h>
 
+
+struct ipv4_listen_case
+{
+        struct sockaddr_in const addr;
+        char const *const desc;
+};
+
+struct ipv6_listen_case
+{
+        struct sockaddr_in6 const addr;
+        char const *const desc;
+};
+
+/**
+ * @brief Initialize test case to listed on IPv4 loopback address.
+ *
+ * @param[in] port IP port to listen on.
+ */
+#define INIT_IPV4_TEST_CASE(port)                                       \
+        {                                                               \
+                .addr = {                                               \
+                        .sin_family = AF_INET,                          \
+                        .sin_port   = htons(port),                      \
+                        .sin_addr   = {                                 \
+                                .s_addr = htonl(INADDR_LOOPBACK)        \
+                        }                                               \
+                },                                                      \
+                .desc = "listen - IPv4 on port " L_STRINGIFY(port)      \
+        }
+
+/**
+ * @brief Initialize test case to listed on IPv6 loopback address.
+ *
+ * @param[in] port IP port to listen on.
+ */
+#define INIT_IPV6_TEST_CASE(port)                                       \
+        {                                                               \
+                .addr = {                                               \
+                        .sin6_family = AF_INET6,                        \
+                        .sin6_port   = htons(port),                     \
+                        .sin6_addr   = { .s6_addr = { [15] = 0x01 } }   \
+                },                                                      \
+                .desc = "listen - IPv6 on port " L_STRINGIFY(port)      \
+        }
+
+// -----------------------------------------------------------------------
 
 static struct mptcpd_lm *_lm;
 
@@ -47,7 +95,6 @@ static void test_close(void const *test_data)
         assert(mptcpd_lm_close(_lm, sa));
 }
 
-
 static void test_destroy(void const *test_data)
 {
         (void) test_data;
@@ -58,43 +105,56 @@ static void test_destroy(void const *test_data)
 int main(int argc, char *argv[])
 {
         l_log_set_stderr();
+        //l_debug_enable("*");
 
         l_test_init(&argc, &argv);
 
         /*
-          Listen on the loopback address since we need an address
-          backed by a network interface so that underlying bind() call
-          can succeed.
+          Listen on the IPv4 and IPv6 loopback addresses since we need
+          an address backed by a network interface so that the
+          underlying bind() call can succeed.
         */
-        struct sockaddr_in addr4 = {
-            .sin_family = AF_INET,
-            .sin_addr   = { .s_addr = htonl(INADDR_LOOPBACK) }
+        struct ipv4_listen_case const ipv4_cases[] = {
+                INIT_IPV4_TEST_CASE(0x3456),
+                INIT_IPV4_TEST_CASE(0x3457),
+                INIT_IPV4_TEST_CASE(0x3456),  // Same port as above.
+                INIT_IPV4_TEST_CASE(0)
         };
 
-        struct sockaddr const *const sa4 =
-            (struct sockaddr const *) &addr4;
-
-        /*
-          Listen on the loopback address since we need an address
-          backed by a network interface so that underlying bind() call
-          can succeed.
-        */
-        struct sockaddr_in6 addr6 = {
-            .sin6_family = AF_INET6
+        struct ipv6_listen_case const ipv6_cases[] = {
+                INIT_IPV6_TEST_CASE(0x4567),
+                INIT_IPV6_TEST_CASE(0x4578),
+                INIT_IPV6_TEST_CASE(0x4567),  // Same port as above.
+                INIT_IPV6_TEST_CASE(0)
         };
 
-        addr6.sin6_addr = in6addr_loopback;
 
-        struct sockaddr const *const sa6 =
-            (struct sockaddr const *) &addr6;
+        l_test_add("create lm", test_create, NULL);
 
-        l_test_add("create listener manager",  test_create,  NULL);
-        l_test_add("listen - IPv4 - FIRST",    test_listen,  sa4);
-        l_test_add("listen - IPv6",            test_listen,  sa6);
-        l_test_add("listen - IPv4 - SECOND",   test_listen,  sa4);
-        l_test_add("close  - IPv4",            test_close,   sa4);
-        l_test_add("close  - IPv6",            test_close,   sa6);
-        l_test_add("destroy listener manager", test_destroy, NULL);
+        for (size_t i = 0; i < L_ARRAY_SIZE(ipv4_cases); ++i) {
+                char const *const desc = ipv4_cases[i].desc;
+                struct sockaddr const *const sa =
+                        (struct sockaddr const *) &ipv4_cases[i].addr;
+
+                l_test_add(desc, test_listen, sa);
+        }
+
+        for (size_t i = 0; i < L_ARRAY_SIZE(ipv6_cases); ++i) {
+                char const *const desc = ipv6_cases[i].desc;
+                struct sockaddr const *const sa =
+                        (struct sockaddr const *) &ipv6_cases[i].addr;
+
+                l_test_add(desc, test_listen, sa);
+        }
+
+        l_test_add("close  - IPv4",
+                   test_close,
+                   (struct sockaddr const *) &ipv4_cases[0]);
+        l_test_add("close  - IPv6",
+                   test_close,
+                   (struct sockaddr const *) &ipv6_cases[0]);
+
+        l_test_add("destroy lm",    test_destroy, NULL);
 
         return l_test_run();
 }

--- a/tests/test-listener-manager.c
+++ b/tests/test-listener-manager.c
@@ -14,7 +14,7 @@
 #include <ell/test.h>
 #include <ell/hashmap.h>
 
-#include "../src/listener_manager.h"
+#include <mptcpd/listener_manager.h>
 
 #include "test-plugin.h"  // For test sockaddrs
 

--- a/tests/test-listener-manager.c
+++ b/tests/test-listener-manager.c
@@ -27,13 +27,13 @@
 
 struct ipv4_listen_case
 {
-        struct sockaddr_in const addr;
+        struct sockaddr_in addr;
         char const *const desc;
 };
 
 struct ipv6_listen_case
 {
-        struct sockaddr_in6 const addr;
+        struct sockaddr_in6 addr;
         char const *const desc;
 };
 
@@ -92,10 +92,13 @@ static void test_create(void const *test_data)
 
 static void test_listen(void const *test_data)
 {
-        struct sockaddr const *const sa = test_data;
+        struct sockaddr *const sa = (struct sockaddr *) test_data;
 
         in_port_t const original_port = get_port(sa);
-        in_port_t port = mptcpd_lm_listen(_lm, sa);
+
+        assert(mptcpd_lm_listen(_lm, sa));
+
+        in_port_t port = get_port(sa);
 
         assert(port != 0);
 
@@ -109,11 +112,9 @@ static void test_listen(void const *test_data)
 
 static void test_listen_bad_address(void const *test_data)
 {
-        struct sockaddr const *const sa = test_data;
+        struct sockaddr *const sa = (struct sockaddr *) test_data;
 
-        in_port_t const port = mptcpd_lm_listen(_lm, sa);
-
-        assert(port == 0);
+        assert(!mptcpd_lm_listen(_lm, sa));
 }
 
 static void test_close(void const *test_data)
@@ -149,14 +150,14 @@ int main(int argc, char *argv[])
           an address backed by a network interface so that the
           underlying bind() call can succeed.
         */
-        struct ipv4_listen_case const ipv4_cases[] = {
+        struct ipv4_listen_case ipv4_cases[] = {
                 INIT_IPV4_TEST_CASE(0x3456),
                 INIT_IPV4_TEST_CASE(0x3457),
                 INIT_IPV4_TEST_CASE(0x3456),  // Same port as above.
                 INIT_IPV4_TEST_CASE(0)
         };
 
-        struct ipv6_listen_case const ipv6_cases[] = {
+        struct ipv6_listen_case ipv6_cases[] = {
                 INIT_IPV6_TEST_CASE(0x4567),
                 INIT_IPV6_TEST_CASE(0x4578),
                 INIT_IPV6_TEST_CASE(0x4567),  // Same port as above.
@@ -176,7 +177,7 @@ int main(int argc, char *argv[])
         }
 
         // Test listen failure with "bad" (unbound) addresses.
-        struct sockaddr_in const ipv4_bad_cases[] = {
+        struct sockaddr_in ipv4_bad_cases[] = {
                 {
                         .sin_family = AF_INET,
                         .sin_addr = { .s_addr = INADDR_ANY }

--- a/tests/test-listener-manager.c
+++ b/tests/test-listener-manager.c
@@ -22,8 +22,7 @@
 #include <assert.h>
 
 
-static struct l_hashmap *_lm;
-static mptcpd_aid_t const _id = 245;
+static struct mptcpd_lm *_lm;
 
 static void test_create(void const *test_data)
 {
@@ -36,29 +35,16 @@ static void test_create(void const *test_data)
 
 static void test_listen(void const *test_data)
 {
-        (void) test_data;
+        struct sockaddr const *const sa = test_data;
 
-        /*
-          Listen on the loopback address since we need an address
-          backed by a network interface so that underlying bind() call
-          can succeed.
-        */
-        struct sockaddr_in addr = {
-            .sin_family = AF_INET,
-            .sin_addr   = { .s_addr = htonl(INADDR_LOOPBACK) }
-        };
-
-        struct sockaddr const *const sa =
-            (struct sockaddr const *) &addr;
-
-        assert(mptcpd_lm_listen(_lm, _id, sa));
+        assert(mptcpd_lm_listen(_lm, sa));
 }
 
 static void test_close(void const *test_data)
 {
-        (void) test_data;
+        struct sockaddr const *const sa = test_data;
 
-        assert(mptcpd_lm_close(_lm, _id));
+        assert(mptcpd_lm_close(_lm, sa));
 }
 
 
@@ -75,10 +61,40 @@ int main(int argc, char *argv[])
 
         l_test_init(&argc, &argv);
 
-        l_test_add("create listener manager",  test_create,    NULL);
-        l_test_add("listen",                   test_listen,    NULL);
-        l_test_add("close",                    test_close,     NULL);
-        l_test_add("destroy listener manager", test_destroy,   NULL);
+        /*
+          Listen on the loopback address since we need an address
+          backed by a network interface so that underlying bind() call
+          can succeed.
+        */
+        struct sockaddr_in addr4 = {
+            .sin_family = AF_INET,
+            .sin_addr   = { .s_addr = htonl(INADDR_LOOPBACK) }
+        };
+
+        struct sockaddr const *const sa4 =
+            (struct sockaddr const *) &addr4;
+
+        /*
+          Listen on the loopback address since we need an address
+          backed by a network interface so that underlying bind() call
+          can succeed.
+        */
+        struct sockaddr_in6 addr6 = {
+            .sin6_family = AF_INET6
+        };
+
+        addr6.sin6_addr = in6addr_loopback;
+
+        struct sockaddr const *const sa6 =
+            (struct sockaddr const *) &addr6;
+
+        l_test_add("create listener manager",  test_create,  NULL);
+        l_test_add("listen - IPv4 - FIRST",    test_listen,  sa4);
+        l_test_add("listen - IPv6",            test_listen,  sa6);
+        l_test_add("listen - IPv4 - SECOND",   test_listen,  sa4);
+        l_test_add("close  - IPv4",            test_close,   sa4);
+        l_test_add("close  - IPv6",            test_close,   sa6);
+        l_test_add("destroy listener manager", test_destroy, NULL);
 
         return l_test_run();
 }

--- a/tests/test-murmur-hash.c
+++ b/tests/test-murmur-hash.c
@@ -40,7 +40,7 @@ static void test_hash_32(void const *test_data)
         uint8_t  const k3[16] = {
             [0]  = 0x20,
             [1]  = 0x01,
-            [2]  = 0X0D,
+            [2]  = 0x0D,
             [3]  = 0xB8,
             [14] = 0x01,
             [15] = 0x02

--- a/tests/test-path-manager.c
+++ b/tests/test-path-manager.c
@@ -90,17 +90,28 @@ static void test_pm_create(void const *test_data)
 {
         struct test_info *const info = (struct test_info *) test_data;
 
-        info->pm = mptcpd_pm_create(info->config);
+        struct mptcpd_pm *const pm = mptcpd_pm_create(info->config);
 
-        assert(info->pm       != NULL);
-        assert(info->pm->genl != NULL);
-        assert(info->pm->nm   != NULL);
+        assert(pm            != NULL);
+        assert(pm->config    != NULL);
+        assert(pm->genl      != NULL);
+        assert(pm->timeout   != NULL);
+        assert(pm->nm        != NULL);
+        assert(pm->idm       != NULL);
+        assert(pm->lm        != NULL);
+        assert(pm->event_ops != NULL);
+
+        assert(mptcpd_pm_get_nm(pm)  == pm->nm);
+        assert(mptcpd_pm_get_idm(pm) == pm->idm);
+        assert(mptcpd_pm_get_lm(pm)  == pm->lm);
 
         /*
           Other struct mptcpd_pm fields may not have been initialized
           yet since they depend on the existence of the "mptcp"
           generic netlink family.
         */
+
+        info->pm = pm;
 }
 
 static void test_pm_register_ops(void const *test_data)

--- a/tests/test-plugin.c
+++ b/tests/test-plugin.c
@@ -207,7 +207,7 @@ static void test_plugin_dispatch(void const *test_data)
 
         // Notice that we call plugin 1 twice.
         // Plugin 1
-        static struct plugin_call_args const args1 = {
+        struct plugin_call_args const args1 = {
                 .name        = TEST_PLUGIN_ONE,
                 .token       = test_token_1,
                 .raddr_id    = test_raddr_id_1,
@@ -220,7 +220,7 @@ static void test_plugin_dispatch(void const *test_data)
         call_plugin_ops(&test_count_1, &args1);
 
         // Plugin 1 as default (no plugin name specified)
-        static struct plugin_call_args const args1_default = {
+        struct plugin_call_args const args1_default = {
                 .token       = args1.token,
                 .raddr_id    = args1.raddr_id,
                 .laddr       = args1.laddr,
@@ -232,7 +232,7 @@ static void test_plugin_dispatch(void const *test_data)
         call_plugin_ops(&test_count_1, &args1_default);
 
         // Plugin 2
-        static struct plugin_call_args const args2 = {
+        struct plugin_call_args const args2 = {
                 .name        = TEST_PLUGIN_TWO,
                 .token       = test_token_2,
                 .raddr_id    = test_raddr_id_2,

--- a/tests/test-plugin.c
+++ b/tests/test-plugin.c
@@ -47,11 +47,12 @@ static bool run_plugin_load(mode_t mode, struct l_queue const *queue)
 
         if (loaded) {
                 static struct plugin_call_args const args = {
-                        .token    = test_token_4,
-                        .raddr_id = test_raddr_id_4,
-                        .laddr    = (struct sockaddr const *) &test_laddr_4,
-                        .raddr    = (struct sockaddr const *) &test_raddr_4,
-                        .backup   = test_backup_4
+                        .token       = test_token_4,
+                        .raddr_id    = test_raddr_id_4,
+                        .laddr       = (struct sockaddr const *) &test_laddr_4,
+                        .raddr       = (struct sockaddr const *) &test_raddr_4,
+                        .backup      = test_backup_4,
+                        .server_side = test_server_side_4
                 };
 
                 call_plugin_ops(&test_count_4, &args);
@@ -180,6 +181,7 @@ static void test_nonexistent_plugins(void const *test_data)
                                      0,     // token
                                      NULL,  // laddr
                                      NULL,  // raddr
+                                     false, // server_side
                                      NULL); // pm
 
         assert(!loaded);
@@ -206,35 +208,38 @@ static void test_plugin_dispatch(void const *test_data)
         // Notice that we call plugin 1 twice.
         // Plugin 1
         static struct plugin_call_args const args1 = {
-                .name     = TEST_PLUGIN_ONE,
-                .token    = test_token_1,
-                .raddr_id = test_raddr_id_1,
-                .laddr    = (struct sockaddr const *) &test_laddr_1,
-                .raddr    = (struct sockaddr const *) &test_raddr_1,
-                .backup   = test_backup_1
+                .name        = TEST_PLUGIN_ONE,
+                .token       = test_token_1,
+                .raddr_id    = test_raddr_id_1,
+                .laddr       = (struct sockaddr const *) &test_laddr_1,
+                .raddr       = (struct sockaddr const *) &test_raddr_1,
+                .backup      = test_backup_1,
+                .server_side = test_server_side_1
         };
 
         call_plugin_ops(&test_count_1, &args1);
 
         // Plugin 1 as default (no plugin name specified)
         static struct plugin_call_args const args1_default = {
-                .token    = test_token_1,
-                .raddr_id = test_raddr_id_1,
-                .laddr    = (struct sockaddr const *) &test_laddr_1,
-                .raddr    = (struct sockaddr const *) &test_raddr_1,
-                .backup   = test_backup_1
+                .token       = test_token_1,
+                .raddr_id    = test_raddr_id_1,
+                .laddr       = (struct sockaddr const *) &test_laddr_1,
+                .raddr       = (struct sockaddr const *) &test_raddr_1,
+                .backup      = test_backup_1,
+                .server_side = test_server_side_1
         };
 
         call_plugin_ops(&test_count_1, &args1_default);
 
         // Plugin 2
         static struct plugin_call_args const args2 = {
-                .name     = TEST_PLUGIN_TWO,
-                .token    = test_token_2,
-                .raddr_id = test_raddr_id_2,
-                .laddr    = (struct sockaddr const *) &test_laddr_2,
-                .raddr    = (struct sockaddr const *) &test_raddr_2,
-                .backup   = test_backup_2
+                .name        = TEST_PLUGIN_TWO,
+                .token       = test_token_2,
+                .raddr_id    = test_raddr_id_2,
+                .laddr       = (struct sockaddr const *) &test_laddr_2,
+                .raddr       = (struct sockaddr const *) &test_raddr_2,
+                .backup      = test_backup_2,
+                .server_side = test_server_side_2
         };
 
         call_plugin_ops(&test_count_2, &args2);
@@ -257,6 +262,7 @@ static void test_plugin_dispatch(void const *test_data)
                 test_bad_token,
                 (struct sockaddr const *) &test_laddr_2,
                 (struct sockaddr const *) &test_raddr_2,
+                test_server_side_2,
                 NULL);
 
         // Test assertions will be triggered during plugin unload.
@@ -293,11 +299,12 @@ static void test_null_plugin_ops(void const *test_data)
         static struct sockaddr const *const laddr = NULL;
         static struct sockaddr const *const raddr = NULL;
         static bool backup = false;
+        static bool server_side = false;
         static struct mptcpd_interface const *const interface = NULL;
 
         // No dispatch should occur in the following calls.
-        mptcpd_plugin_new_connection(name, token, laddr, raddr, pm);
-        mptcpd_plugin_connection_established(token, laddr, raddr, pm);
+        mptcpd_plugin_new_connection(name, token, laddr, raddr, server_side, pm);
+        mptcpd_plugin_connection_established(token, laddr, raddr, server_side, pm);
         mptcpd_plugin_connection_closed(token, pm);
         mptcpd_plugin_new_address(token, id, raddr, pm);
         mptcpd_plugin_address_removed(token, id, pm);

--- a/tests/test-plugin.c
+++ b/tests/test-plugin.c
@@ -221,12 +221,12 @@ static void test_plugin_dispatch(void const *test_data)
 
         // Plugin 1 as default (no plugin name specified)
         static struct plugin_call_args const args1_default = {
-                .token       = test_token_1,
-                .raddr_id    = test_raddr_id_1,
-                .laddr       = (struct sockaddr const *) &test_laddr_1,
-                .raddr       = (struct sockaddr const *) &test_raddr_1,
-                .backup      = test_backup_1,
-                .server_side = test_server_side_1
+                .token       = args1.token,
+                .raddr_id    = args1.raddr_id,
+                .laddr       = args1.laddr,
+                .raddr       = args1.raddr,
+                .backup      = args1.backup,
+                .server_side = args1.server_side
         };
 
         call_plugin_ops(&test_count_1, &args1_default);

--- a/tests/test-sockaddr.c
+++ b/tests/test-sockaddr.c
@@ -149,7 +149,7 @@ static void test_copy_af_inet6(void const *test_data)
                 .sin6_addr   = {
                         .s6_addr = { [0]  = 0x20,
                                      [1]  = 0x01,
-                                     [2]  = 0X0D,
+                                     [2]  = 0x0D,
                                      [3]  = 0xB8,
                                      [14] = 0x01,
                                      [15] = 0x02 }  // 2001:DB8::102

--- a/tests/test-sockaddr.c
+++ b/tests/test-sockaddr.c
@@ -9,9 +9,12 @@
 
 #include <sys/un.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <ell/log.h>
 #include <ell/test.h>
 #include <ell/util.h>
+#pragma GCC diagnostic pop
 
 #include <mptcpd/private/sockaddr.h>
 

--- a/tests/test-sockaddr.c
+++ b/tests/test-sockaddr.c
@@ -7,8 +7,11 @@
  * Copyright (c) 2021, 2022, Intel Corporation
  */
 
+#include <sys/un.h>
+
 #include <ell/log.h>
 #include <ell/test.h>
+#include <ell/util.h>
 
 #include <mptcpd/private/sockaddr.h>
 
@@ -101,6 +104,73 @@ static void test_sockaddr_in6_init(void const *test_data)
                                     (struct sockaddr const *) &addr));
 }
 
+static void test_copy_null(void const *test_data)
+{
+        (void) test_data;
+
+        assert(mptcpd_sockaddr_copy(NULL) == NULL);
+}
+
+static bool test_copy_inet(struct sockaddr const *src)
+{
+        struct sockaddr *const dst = mptcpd_sockaddr_copy(src);
+
+        bool const is_equal = sockaddr_is_equal(src, dst);
+
+        l_free(dst);
+
+        return is_equal;
+}
+
+static void test_copy_af_inet(void const *test_data)
+{
+        (void) test_data;
+
+        struct sockaddr_in const addr = {
+                .sin_family = AF_INET,
+                .sin_port   = htons(0x1234),
+                .sin_addr   = {
+                        .s_addr = htonl(0xC0000201) // 192.0.2.1
+                }
+        };
+
+        struct sockaddr const *const src = (struct sockaddr const *) &addr;
+
+        assert(test_copy_inet(src));
+}
+
+static void test_copy_af_inet6(void const *test_data)
+{
+        (void) test_data;
+
+        struct sockaddr_in6 const addr = {
+                .sin6_family = AF_INET6,
+                .sin6_port   = htons(0x5678),
+                .sin6_addr   = {
+                        .s6_addr = { [0]  = 0x20,
+                                     [1]  = 0x01,
+                                     [2]  = 0X0D,
+                                     [3]  = 0xB8,
+                                     [14] = 0x01,
+                                     [15] = 0x02 }  // 2001:DB8::102
+                }
+        };
+
+        struct sockaddr const *const src =
+                (struct sockaddr const *) &addr;
+
+        assert(test_copy_inet(src));
+}
+
+static void test_copy_non_inet(void const *test_data)
+{
+        (void) test_data;
+
+        struct sockaddr const src = { .sa_family = AF_UNIX };
+
+        assert(mptcpd_sockaddr_copy(&src) == NULL);
+}
+
 int main(int argc, char *argv[])
 {
         l_log_set_stderr();
@@ -111,6 +181,10 @@ int main(int argc, char *argv[])
         l_test_add("bad sockaddr init", test_bad_sockaddr_init, NULL);
         l_test_add("sockaddr_in init",  test_sockaddr_in_init,  NULL);
         l_test_add("sockaddr_in6 init", test_sockaddr_in6_init, NULL);
+        l_test_add("copy - NULL",       test_copy_null,         NULL);
+        l_test_add("copy - AF_INET",    test_copy_af_inet,      NULL);
+        l_test_add("copy - AF_INET6",   test_copy_af_inet6,     NULL);
+        l_test_add("copy - non-INET",   test_copy_non_inet,     NULL);
 
         return l_test_run();
 }


### PR DESCRIPTION
Implement support for the upcoming MPTCP netlink user space path commands commands in the upstream kernel. See multipath-tcp/mptcp_net-next#186 for the corresponding kernel-side GitHub issue.

Closes #129.
Closes #244.