### PR TITLE
Fix issues flagged by Lintian.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -314,8 +314,8 @@ AS_IF([test "x$enable_stack_protection" = "xyes"],
        # implicitly defined under some levels optimization.
        #
        # Note that _FORTIFY_SOURCE is defined on the preprocessor
-       # command line instead of in <mptcpd/config.h> since the
-       # latter is not included all mptcpd source files, and may be
+       # command line instead of in <mptcpd/config.h> since the latter
+       # is not included in all mptcpd source files, and may also be
        # included after C library headers.
        AC_CHECK_DEFINE([_FORTIFY_SOURCE],
                        [],

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 #
-# Copyright (c) 2017-2021, Intel Corporation
+# Copyright (c) 2017-2022, Intel Corporation
 
 AC_PREREQ([2.69])
 AC_INIT([mptcpd],

--- a/configure.ac
+++ b/configure.ac
@@ -305,21 +305,29 @@ AC_ARG_ENABLE(stack-protection,
         [enable_stack_protection=yes])
 
 AS_IF([test "x$enable_stack_protection" = "xyes"],
-        [
-        # Fortify source
-        # Enabling optimization implies _FORTIFY_SOURCE on some platforms.
-        # Explicitly redefine to _FORTIFY_SOURCE=2 to make sure we have the
-        # desired fortification level.
-        AX_APPEND_FLAG([-U_FORTIFY_SOURCE], [CPPFLAGS])
-        AX_APPEND_FLAG([-D_FORTIFY_SOURCE=2], [CPPFLAGS])
+      [
+       # Harden/fortify source
+       #
+       # _FORTIFY_SOURCE=2 is the desired level of fortification for
+       # mptcpd, but we should still avoid overriding user defined
+       # values, including the case where _FORTIFY_SOURCE is
+       # implicitly defined under some levels optimization.
+       #
+       # Note that _FORTIFY_SOURCE is defined on the preprocessor
+       # command line instead of in <mptcpd/config.h> since the
+       # latter is not included all mptcpd source files, and may be
+       # included after C library headers.
+       AC_CHECK_DEFINE([_FORTIFY_SOURCE],
+                       [],
+                       [AX_APPEND_FLAG([-D_FORTIFY_SOURCE=2], [CPPFLAGS])])
 
-        # Stack-based buffer overrun detection
-        MPTCPD_ADD_COMPILE_FLAG([-fstack-protector-strong],
-                                [# GCC < 4.9
-                                 MPTCPD_ADD_COMPILE_FLAG([-fstack-protector])
-                                ])
-        ],[]
-        )
+       # Stack-based buffer overrun detection
+       MPTCPD_ADD_COMPILE_FLAG([-fstack-protector-strong],
+                               [# GCC < 4.9
+                                MPTCPD_ADD_COMPILE_FLAG([-fstack-protector])
+                               ])
+      ],
+      [])
 
 # Format string vulnerabilities
 # -Wformat=2 implies:

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -64,21 +64,21 @@ endif
 
 pkglib_LTLIBRARIES = libmptcpwrap.la
 
-mptcpd_SOURCES  = mptcpd.c
-mptcpd_LDADD    =				\
+mptcpd_SOURCES = mptcpd.c
+mptcpd_LDADD   =				\
 	$(builddir)/libpath_manager.la		\
 	$(ELL_LIBS) $(CODE_COVERAGE_LIBS)
-mptcpd_LDFLAGS  = $(EXECUTABLE_LDFLAGS)
+mptcpd_LDFLAGS = $(EXECUTABLE_LDFLAGS)
 
 librevision=1
 
-mptcpize_SOURCES = mptcpize.c
+mptcpize_SOURCES  = mptcpize.c
 mptcpize_CPPFLAGS = \
 	$(AM_CPPFLAGS)			\
 	-DPKGLIBDIR=\"$(pkglibdir)\"	\
 	-DLIBREVISION=\"$(librevision)\"
-mptcpize_LDADD =  $(CODE_COVERAGE_LIBS)
-mptcpize_LDFLAGS = $(EXECUTABLE_LDFLAGS)
+mptcpize_LDADD    = $(CODE_COVERAGE_LIBS)
+mptcpize_LDFLAGS  = $(EXECUTABLE_LDFLAGS)
 
 libmptcpwrap_la_SOURCES = mptcpwrap.c
 libmptcpwrap_la_CFLAGS  = $(CODE_COVERAGE_CFLAGS)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -78,6 +78,7 @@ mptcpize_CPPFLAGS = \
 	-DPKGLIBDIR=\"$(pkglibdir)\"	\
 	-DLIBREVISION=\"$(librevision)\"
 mptcpize_LDADD =  $(CODE_COVERAGE_LIBS)
+mptcpize_LDFLAGS = $(EXECUTABLE_LDFLAGS)
 
 libmptcpwrap_la_SOURCES = mptcpwrap.c
 libmptcpwrap_la_LDFLAGS = -version-info 0:$(librevision):0

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -81,6 +81,7 @@ mptcpize_LDADD =  $(CODE_COVERAGE_LIBS)
 mptcpize_LDFLAGS = $(EXECUTABLE_LDFLAGS)
 
 libmptcpwrap_la_SOURCES = mptcpwrap.c
+libmptcpwrap_la_CFLAGS  = $(CODE_COVERAGE_CFLAGS)
 libmptcpwrap_la_LDFLAGS = -version-info 0:$(librevision):0
 libmptcpwrap_la_LIBADD  = $(CODE_COVERAGE_LIBS)
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -62,7 +62,8 @@ else
 bin_PROGRAMS = mptcpd mptcpize
 endif
 
-pkglib_LTLIBRARIES = libmptcpwrap.la
+mptcpizelibdir = $(libdir)/mptcpize
+mptcpizelib_LTLIBRARIES = libmptcpwrap.la
 
 mptcpd_SOURCES = mptcpd.c
 mptcpd_LDADD   =				\
@@ -75,7 +76,7 @@ librevision=1
 mptcpize_SOURCES  = mptcpize.c
 mptcpize_CPPFLAGS = \
 	$(AM_CPPFLAGS)			\
-	-DPKGLIBDIR=\"$(pkglibdir)\"	\
+	-DPKGLIBDIR=\"$(mptcpizelibdir)\" \
 	-DLIBREVISION=\"$(librevision)\"
 mptcpize_LDADD    = $(CODE_COVERAGE_LIBS)
 mptcpize_LDFLAGS  = $(EXECUTABLE_LDFLAGS)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,6 +1,6 @@
 ## SPDX-License-Identifier: BSD-3-Clause
 ##
-## Copyright (c) 2017-2019, 2021, Intel Corporation
+## Copyright (c) 2017-2019, 2021-2022, Intel Corporation
 
 include $(top_srcdir)/aminclude_static.am
 

--- a/src/mptcp.service.in
+++ b/src/mptcp.service.in
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
-# Copyright (c) 2017-2019, Intel Corporation
+# Copyright (c) 2017-2019, 2021, Intel Corporation
 
 [Unit]
 Description=Multipath TCP service
@@ -16,4 +16,4 @@ AmbientCapabilities=CAP_NET_ADMIN
 LimitNPROC=1
 
 [Install]
-WantedBy=sockets.target
+WantedBy=multi-user.target

--- a/src/mptcp.service.in
+++ b/src/mptcp.service.in
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
-# Copyright (c) 2017-2019, 2021, Intel Corporation
+# Copyright (c) 2017-2019, 2022, Intel Corporation
 
 [Unit]
 Description=Multipath TCP service


### PR DESCRIPTION
Recent attempts to package mptcpd for Debian triggered several [Lintian](https://lintian.debian.org/) issues.  This set of changes addresses some of them.  The list of mptcpd related Lintian warnings and errors may be found [here](https://paste.opendev.org/show/812263/).
