### PR TITLE
Skip some tests on non-MPTCP kernels.

### DIFF
--- a/tests/lib/test-util.c
+++ b/tests/lib/test-util.c
@@ -22,6 +22,8 @@
 # include <mptcpd/private/mptcp_org.h>
 #endif
 
+#include "../src/netlink_pm.h"  // For MPTCP_SYSCTL_BASE
+
 #include "test-util.h"
 
 
@@ -32,6 +34,12 @@ char const *tests_get_pm_family_name(void)
 #else
         return MPTCP_GENL_NAME;
 #endif
+}
+
+bool tests_is_mptcp_kernel(void)
+{
+        // Kernel supports MPTCP if /proc/sys/net/mptcp exists.
+        return access(MPTCP_SYSCTL_BASE, R_OK | X_OK) == 0;
 }
 
 

--- a/tests/lib/test-util.c
+++ b/tests/lib/test-util.c
@@ -51,7 +51,7 @@ void tests_skip_if_no_mptcp(void)
           as SKIP rather than PASS or FAIL.
 
           Tests that should be skipped under some conditions, such as
-          when not running a MPTCP capable kernel should exit the
+          when not running a MPTCP capable kernel, should exit the
           process with this value.
         */
         static int const SKIP_EXIT_STATUS = 77;

--- a/tests/lib/test-util.c
+++ b/tests/lib/test-util.c
@@ -12,6 +12,7 @@
 #endif
 
 #include <unistd.h>
+#include <stdlib.h>
 
 #if defined(HAVE_LINUX_MPTCP_H_UPSTREAM) \
         || defined(HAVE_LINUX_MPTCP_H_MPTCP_ORG)
@@ -36,11 +37,29 @@ char const *tests_get_pm_family_name(void)
 #endif
 }
 
-bool tests_is_mptcp_kernel(void)
+static bool is_mptcp_kernel(void)
 {
         // Kernel supports MPTCP if /proc/sys/net/mptcp exists.
         return access(MPTCP_SYSCTL_BASE, R_OK | X_OK) == 0;
 }
+
+void tests_skip_if_no_mptcp(void)
+{
+        /*
+          An exit status of 77 causes the Automake test driver,
+          i.e. the `test-driver' script, to consider the test result
+          as SKIP rather than PASS or FAIL.
+
+          Tests that should be skipped under some conditions, such as
+          when not running a MPTCP capable kernel should exit the
+          process with this value.
+        */
+        static int const SKIP_EXIT_STATUS = 77;
+
+        if (!is_mptcp_kernel())
+                exit(SKIP_EXIT_STATUS);
+}
+
 
 
 /*

--- a/tests/lib/test-util.h
+++ b/tests/lib/test-util.h
@@ -4,7 +4,7 @@
  *
  * @brief mptcpd test utilities library.
  *
- * Copyright (c) 2020, Intel Corporation
+ * Copyright (c) 2020, 2022, Intel Corporation
  */
 
 #ifndef MPTCP_TEST_UTIL_H
@@ -12,6 +12,8 @@
 
 
 char const *tests_get_pm_family_name(void);
+
+bool tests_is_mptcp_kernel(void);
 
 
 #endif  // MPTCP_TEST_UTIL_H

--- a/tests/lib/test-util.h
+++ b/tests/lib/test-util.h
@@ -10,9 +10,24 @@
 #ifndef MPTCP_TEST_UTIL_H
 #define MPTCP_TEST_UTIL_H
 
+/**
+ * @brief Automake test driver "skip" exit status.
+ *
+ * An exit status of 77 causes the Automake test driver, i.e. the
+ * @c test-driver script, to consider the test as skipped rather than
+ * passed or failed.
+ *
+ * Tests that should be skipped under some conditions, such as when
+ * not running a MPTCP capable kernel should exit the process with
+ * this value.
+ */
+#define TESTS_SKIP_EXIT_STATUS 77
 
+
+/// Get MPTCP path management generic netlink API family name.
 char const *tests_get_pm_family_name(void);
 
+/// Is the kernel MPTCP capable?
 bool tests_is_mptcp_kernel(void);
 
 

--- a/tests/lib/test-util.h
+++ b/tests/lib/test-util.h
@@ -10,25 +10,20 @@
 #ifndef MPTCP_TEST_UTIL_H
 #define MPTCP_TEST_UTIL_H
 
-/**
- * @brief Automake test driver "skip" exit status.
- *
- * An exit status of 77 causes the Automake test driver, i.e. the
- * @c test-driver script, to consider the test as skipped rather than
- * passed or failed.
- *
- * Tests that should be skipped under some conditions, such as when
- * not running a MPTCP capable kernel should exit the process with
- * this value.
- */
-#define TESTS_SKIP_EXIT_STATUS 77
-
 
 /// Get MPTCP path management generic netlink API family name.
 char const *tests_get_pm_family_name(void);
 
-/// Is the kernel MPTCP capable?
-bool tests_is_mptcp_kernel(void);
+/**
+ * @brief Exit test process if the kernel does not support MPTCP.
+ *
+ * If the kernel does not support MPTCP exit the current test process
+ * with an exit status suitable for making the Automake @c test-driver
+ * script interpret the test result as @c SKIP instead of @c PASS or
+ * @c FAIL.  This is useful for tests that need MPTCP but are run on
+ * platforms with a non-MPTCP capable kernel.
+ */
+void tests_skip_if_no_mptcp(void);
 
 
 #endif  // MPTCP_TEST_UTIL_H

--- a/tests/test-commands.c
+++ b/tests/test-commands.c
@@ -571,8 +571,7 @@ static void idle_callback(struct l_idle *idle, void *user_data)
 int main(void)
 {
         // Skip this test if the kernel is not MPTCP capable.
-        if (!tests_is_mptcp_kernel())
-                return TESTS_SKIP_EXIT_STATUS;
+        tests_skip_if_no_mptcp();
 
         if (!l_main_init())
                 return -1;

--- a/tests/test-commands.c
+++ b/tests/test-commands.c
@@ -570,6 +570,10 @@ static void idle_callback(struct l_idle *idle, void *user_data)
 
 int main(void)
 {
+        // Skip this test if the kernel is not MPTCP capable.
+        if (!tests_is_mptcp_kernel())
+                return TESTS_SKIP_EXIT_STATUS;
+
         if (!l_main_init())
                 return -1;
 

--- a/tests/test-mptcpwrap
+++ b/tests/test-mptcpwrap
@@ -7,15 +7,18 @@
 
 set -e
 
+# An exit status of 77 causes the Automake test driver to consider the
+# test as skipped.
+skip_exit_status=77
+
 # Check if we're using the upstream kernel.
 #
-# upstream:          net.mptcp.enabled
-# multipath-tcp.org: net.mptcp.mptcp_enabled
-key=`sysctl --names --pattern 'mptcp\.enabled' net.mptcp`
-if [ -z "$key" ]; then
-    # Do not run the test if we're not using the upstream kernel.
+# upstream:          /proc/sys/net/mptcp/enabled
+# multipath-tcp.org: /proc/sys/net/mptcp/mptcp_enabled
+if [ ! -f /proc/sys/net/mptcp/enabled ]; then
+    # Skip the test if we're not using the upstream kernel.
     echo Not running upstream kernel.  libmptcpwrap will not be tested.
-    exit 0
+    exit $skip_exit_status
 fi
 
 LD_PRELOAD=../src/.libs/libmptcpwrap.so \

--- a/tests/test-path-manager.c
+++ b/tests/test-path-manager.c
@@ -161,6 +161,10 @@ static void timeout_callback(struct l_timeout *timeout,
 
 int main(void)
 {
+        // Skip this test if the kernel is not MPTCP capable.
+        if (!tests_is_mptcp_kernel())
+                return TESTS_SKIP_EXIT_STATUS;
+
         if (!l_main_init())
                 return -1;
 

--- a/tests/test-path-manager.c
+++ b/tests/test-path-manager.c
@@ -162,8 +162,7 @@ static void timeout_callback(struct l_timeout *timeout,
 int main(void)
 {
         // Skip this test if the kernel is not MPTCP capable.
-        if (!tests_is_mptcp_kernel())
-                return TESTS_SKIP_EXIT_STATUS;
+        tests_skip_if_no_mptcp();
 
         if (!l_main_init())
                 return -1;


### PR DESCRIPTION
The mptcpd unit tests test-commands, test-path-manager and test-mptcpwrap require a MPTCP capable kernel to run.  Make those tests return with an exit status (77) that causes the Automake test driver script, i.e. `test-driver' to treat the tests as skipped.  This allows the test suite to succeed when MPTCP is not available in the kernel.

The test summary from a `make check' run would look similar to the following when run on a non-MPTCP capable kernel:
```
...
PASS: test-network-monitor
SKIP: test-path-manager
SKIP: test-commands
PASS: test-configuration
...
SKIP: test-mptcpwrap
============================================================================
Testsuite summary for mptcpd 0.9
============================================================================
# TOTAL: 17
# PASS:  14
# SKIP:  3
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```
 Fixes #204.