### PR TITLE
configure: Improve MPTCP kernel detection.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -205,35 +205,7 @@ AC_SUBST([ELL_VERSION])
 # @todo mptcpd ships with a copies of the upstream and
 #       multipath-tcp.org kernel <linux/mptcp.h> header files. Ideally
 #       it should not. Consider removing them from mptcpd.
-AH_TEMPLATE([HAVE_LINUX_MPTCP_H_UPSTREAM],
-            [Define to 1 if you have the upstream kernel
-            <linux/mptcp.h> header.])
-AH_TEMPLATE([HAVE_LINUX_MPTCP_H_MPTCP_ORG],
-            [Define to 1 if you have the multipath-tcp.org kernel
-            <linux/mptcp.h> header.])
-AC_CHECK_HEADERS([linux/mptcp.h],
-  [
-   MPTCPD_IF_UPSTREAM_KERNEL(
-     [
-      AC_DEFINE([HAVE_LINUX_MPTCP_H_UPSTREAM], [1])
-      AS_IF([test "x$with_kernel" = "xauto"],
-            [with_kernel=upstream])
-     ],
-     [
-      MPTCPD_IF_MPTCP_ORG_KERNEL(
-        [
-         AC_DEFINE([HAVE_LINUX_MPTCP_H_MPTCP_ORG], [1])
-         AS_IF([test "x$with_kernel" = "xauto"],
-               [with_kernel=multipath-tcp.org])
-        ],
-        [
-         AC_MSG_WARN([Unsupported <linux/mptcp.h> header. Using fallback.])
-        ])
-      ])
-  ],
-  [
-   AC_MSG_WARN([<linux/mptcp.h> header not found. Using fallback.])
-  ])
+MPTCPD_CHECK_LINUX_MPTCP_H
 
 AS_IF([test "x$with_kernel" = "xauto"], [with_kernel=upstream])
 

--- a/m4/mptcpd_kernel.m4
+++ b/m4/mptcpd_kernel.m4
@@ -1,18 +1,49 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
-# Copyright (c) 2021, Intel Corporation
+# Copyright (c) 2021-2022, Intel Corporation
 
-#serial 1
+#serial 2
 
-# MPTCPD_IF_UPSTREAM_KERNEL([ACTION-IF-TRUE], [ACTION-IF-FALSE])
+# MPTCPD_CHECK_KERNEL
 #
-# Check if the <linux/mptcp.h> header for the upstream kernel is
-# available in the system include path.
-AC_DEFUN([MPTCPD_IF_UPSTREAM_KERNEL],
+# Check if a MPTCP capable kernel is in use.
+AC_DEFUN([MPTCPD_CHECK_KERNEL],
 [
+ # upstream:          /proc/sys/net/mptcp/enabled
+ # multipath-tcp.org: /proc/sys/net/mptcp/mptcp_enabled
+ AS_IF([test "x$with_kernel" = "xauto"],
+       [mptcp_sysctl_base="/proc/sys/net/mptcp/"
+        AC_CHECK_FILE(
+          [${mptcp_sysctl_base}enabled],
+          [with_kernel=upstream],
+          [AC_CHECK_FILE(
+             [${mptcp_sysctl_base}mptcp_enabled],
+             [with_kernel=multipath-tcp.org],
+             [with_kernel=upstream
+              AC_MSG_WARN(
+                [No MPTCP capable kernel detected. Assuming upstream.])
+             ])
+          ])
+       ])
+])
+
+# MPTCPD_CHECK_KERNEL_HEADER_UPSTREAM
+#
+# Check if the <linux/mptcp.h> header exists, determine if it
+# corresponds the upstream or multipath-tcp.org kernel, and check if
+# it may be used by mptcpd since older versions may be missing
+# required preprocessor symbols or enumerators.
+AC_DEFUN([MPTCPD_CHECK_KERNEL_HEADER_UPSTREAM],
+[
+ AH_TEMPLATE([HAVE_LINUX_MPTCP_H_UPSTREAM],
+             [Define to 1 if you have the upstream kernel
+             <linux/mptcp.h> header.])
+
  AC_CACHE_CHECK([for MPTCP_PM_CMD_ANNOUNCE in linux/mptcp.h],
    [mptcpd_cv_header_upstream],
    [
+    # Perform a compile-time test since MPTCP_PM_CMD_ANNOUNCE is an
+    # enumerator, not a preprocessor symbol.
     AC_COMPILE_IFELSE([
       AC_LANG_SOURCE([
 #include <linux/mptcp.h>
@@ -24,14 +55,47 @@ int announce_cmd(void) { return MPTCP_PM_CMD_ANNOUNCE; }
     [mptcpd_cv_header_upstream=no])
    ])
 
- AS_IF([test "x$mptcpd_cv_header_upstream" = xyes], [$1], [$2])
+ AS_IF([test "x$mptcpd_cv_header_upstream" = "xyes"],
+       [AC_DEFINE([HAVE_LINUX_MPTCP_H_UPSTREAM], [1])],
+       [AC_MSG_WARN([No usable upstream <linux/mptcp.h>. Using fallback.])])
 ])
 
-# MPTCPD_IF_MPTCP_ORG_KERNEL([ACTION-IF-TRUE], [ACTION-IF-FALSE])
+# MPTCPD_CHECK_KERNEL_HEADER_MPTCP_ORG
 #
-# Check if the <linux/mptcp.h> header for the multipath-tcp.org kernel
-# is available in the system include path.
-AC_DEFUN([MPTCPD_IF_MPTCP_ORG_KERNEL],
+# Check the multipath-tcp.org kernel-specific
+# /proc/sys/net/mptcp/mptcp_enabled file exists.  The
+# multipath-tcp.org kernel is being used if it does.
+AC_DEFUN([MPTCPD_CHECK_KERNEL_HEADER_MPTCP_ORG],
 [
- AX_CHECK_DEFINE([linux/mptcp.h], [MPTCP_GENL_NAME], [$1], [$2])
+ AH_TEMPLATE([HAVE_LINUX_MPTCP_H_MPTCP_ORG],
+             [Define to 1 if you have the multipath-tcp.org kernel
+             <linux/mptcp.h> header.])
+
+ AX_CHECK_DEFINE(
+   [linux/mptcp.h],
+   [MPTCP_GENL_NAME],
+   [AC_DEFINE([HAVE_LINUX_MPTCP_H_MPTCP_ORG], [1])],
+   [AC_MSG_WARN([No usable multipath-tcp.org <linux/mptcp.h>. Using fallback.])])
+])
+
+# MPTCPD_CHECK_LINUX_MPTCP_H
+#
+# Check if the <linux/mptcp.h> header is available in the system or
+# user-specified include path, taking into account the detected or
+# user-selected MPTCP capable kernel.
+AC_DEFUN([MPTCPD_CHECK_LINUX_MPTCP_H],
+[
+ AC_REQUIRE([MPTCPD_CHECK_KERNEL])
+
+ AC_CHECK_HEADERS([linux/mptcp.h],
+  [
+   AS_IF([test "x$with_kernel" = "xupstream"],
+         [MPTCPD_CHECK_KERNEL_HEADER_UPSTREAM])
+
+   AS_IF([test "x$with_kernel" = "xmultipath-tcp.org"],
+         [MPTCPD_CHECK_KERNEL_HEADER_MPTCP_ORG])
+  ],
+  [
+   AC_MSG_WARN([<linux/mptcp.h> header not found. Using fallback.])
+  ])
 ])


### PR DESCRIPTION
Detect a MPTCP capable kernel through the "enabled" file in
`/proc/sys/net/mptcp' rather than the <linux/mptcp.h> header alone if
the user hasn't chosen a specific MPTCP kernel, i.e. "upstream" or
"multipath-tcp.org".  This allows mptcpd to be configured for the
multipath-tcp.org kernel by default if that kernel is at detected at
configure-time rather than always falling back on the upstream
kernel.

Previously, the `configure' script would by default fallback on the
upstream kernel support instead of the multipath-tcp.org kernel when
run on a distro using the latter.