### PR TITLE
doxygen: disable HTML_TIMESTAMP

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1280,7 +1280,7 @@ HTML_COLORSTYLE_GAMMA  = 80
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_TIMESTAMP         = YES
+HTML_TIMESTAMP         = NO
 
 # If the HTML_DYNAMIC_MENUS tag is set to YES then the generated HTML
 # documentation will contain a main index with vertical navigation menus that


### PR DESCRIPTION
This timestamp causes issues for the "Reproducible Builds" project[1-2].

In Debian, it is then recommended to disable this timestamp by default.

Because these packages are linked to a tagged version, the timestamp is
not an important info to keep.

I'm sharing this patch just in case you think it makes sense to disable
it by default. If not, I can maintain this patch just for Debian.

[1] https://reproducible-builds.org/
[2] https://wiki.debian.org/ReproducibleBuilds/TimestampsInDocumentationGeneratedByDoxygen