### PR TITLE
Allow loopback network interface monitoring.

### DIFF
--- a/include/mptcpd/network_monitor.h
+++ b/include/mptcpd/network_monitor.h
@@ -213,6 +213,27 @@ MPTCPD_API bool mptcpd_nm_register_ops(struct mptcpd_nm *nm,
                                        struct mptcpd_nm_ops const *ops,
                                        void *user_data);
 
+/**
+ * @brief Enable monitoring of the loopback network interface.
+ *
+ * Mptcpd normally only monitors non-loopback network interfaces.
+ * Call this function to enable monitoring of loopback network
+ * interfaces.
+ *
+ * @note Mptcpd monitoring of loopback network interfaces is meant
+ *       primarily for testing purposes.
+ *
+ * @param[in,out] nm     Pointer to the mptcpd network monitor
+ *                       object.
+ * @param[in]     enable Enable or disable monitoring of loopback
+ *                       network interfaces.
+ *
+ * @retval true  Successfully enable or disabled.
+ * @retval false Invalid @a nm argument.
+ */
+MPTCPD_API bool mptcpd_nm_monitor_loopback(struct mptcpd_nm *nm,
+                                           bool enable);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/network_monitor.c
+++ b/lib/network_monitor.c
@@ -1444,9 +1444,10 @@ struct mptcpd_nm *mptcpd_nm_create(uint32_t flags)
                 return NULL;
         }
 
-        nm->notify_flags = flags;
-        nm->interfaces   = l_queue_new();
-        nm->ops          = l_queue_new();
+        nm->notify_flags     = flags;
+        nm->interfaces       = l_queue_new();
+        nm->ops              = l_queue_new();
+        nm->monitor_loopback = false;
 
         /**
          * Get network interface information.

--- a/lib/network_monitor.c
+++ b/lib/network_monitor.c
@@ -535,8 +535,8 @@ static bool is_interface_ready(struct mptcpd_nm const *nm,
         static unsigned int iff_ready = IFF_UP | IFF_RUNNING;
 
         return (ifi->ifi_flags & iff_ready) == iff_ready
-                && (nm->monitor_loopback
-                    || (ifi->ifi_flags & IFF_LOOPBACK) == 0);
+                && ((ifi->ifi_flags & IFF_LOOPBACK) == 0
+                    || nm->monitor_loopback);
 }
 
 /**

--- a/lib/network_monitor.c
+++ b/lib/network_monitor.c
@@ -4,7 +4,7 @@
  *
  * @brief mptcpd network device monitoring.
  *
- * Copyright (c) 2017-2021, Intel Corporation
+ * Copyright (c) 2017-2022, Intel Corporation
  */
 
 #ifdef HAVE_CONFIG_H

--- a/tests/test-network-monitor.c
+++ b/tests/test-network-monitor.c
@@ -4,7 +4,7 @@
  *
  * @brief mptcpd network monitor test.
  *
- * Copyright (c) 2018-2020, Intel Corporation
+ * Copyright (c) 2018-2020, 2022, Intel Corporation
  */
 
 #define _DEFAULT_SOURCE  // Enable IFF_... interface flags in <net/if.h>.

--- a/tests/test-network-monitor.c
+++ b/tests/test-network-monitor.c
@@ -115,12 +115,11 @@ static void check_interface(struct mptcpd_interface const *i, void *data)
         l_queue_foreach(i->addrs, dump_addr, NULL);
 
         /*
-          Only non-loopback interfaces that are up and running should
-          be monitored.
+          Only network interfaces that are up and running should be
+          monitored.
         */
         static unsigned int const ready = IFF_UP | IFF_RUNNING;
         assert(ready == (i->flags & ready));
-        assert(!(i->flags & IFF_LOOPBACK));
 
         if (data) {
                 struct foreach_data *const fdata = data;
@@ -248,6 +247,14 @@ int main(void)
 
         struct mptcpd_nm *const nm = mptcpd_nm_create(0);
         assert(nm);
+
+        assert(!mptcpd_nm_monitor_loopback(NULL, true)); // Bad arg
+
+        /*
+          Enable loopback network interface monitoring for this unit
+          test in case non-loopback network interfaces are unavailable.
+        */
+        assert(mptcpd_nm_monitor_loopback(nm, true));
 
         struct mptcpd_nm_ops const nm_events[] = {
                 {


### PR DESCRIPTION
Add a new `mptcpd_nm_monitor_loopback()` function that allows the user to enable monitoring of loopback network interfaces.  Monitoring of loopback network interfaces is meant primarily for testing purposes.  Mptcpd will retain the previous behavior of only monitoring non-loopback network interfaces by default.

Fixes #208.
