### PR TITLE
mptcp: uapi: fix SPDX License comment

### DIFF
--- a/include/linux/mptcp_org.h
+++ b/include/linux/mptcp_org.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
+/* SPDX-License-Identifier: GPL-2.0+ WITH Linux-syscall-note */
 /*
  * Netlink API for Multipath TCP
  *


### PR DESCRIPTION
The license is written just below and clearly mention:

    GNU General Public License (...) either version 2 of the License,
    *or (at your option) any later version*.

This is the GPL-2.0+, not GPL-2.0.

This is sync with upstream (mptcp.org), see:

    commit d8f3b283b485 ("mptcp: uapi: fix SPDX License comment")

Reported-by: Thorsten Alteholz <debian@alteholz.de>
Signed-off-by: Matthieu Baerts <matthieu.baerts@tessares.net>