### PR TITLE
Fix compatibility with ELL 0.45 and later

### DIFF
--- a/lib/id_manager.c
+++ b/lib/id_manager.c
@@ -16,9 +16,12 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <ell/hashmap.h>
 #include <ell/uintset.h>
 #include <ell/util.h>
+#pragma GCC diagnostic pop
 
 #include <mptcpd/private/id_manager.h>
 #include <mptcpd/id_manager.h>

--- a/lib/network_monitor.c
+++ b/lib/network_monitor.c
@@ -23,12 +23,15 @@
 #include <net/if.h>  // For standard network interface flags.
 #include <netinet/in.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <ell/netlink.h>
 #include <ell/log.h>
 #include <ell/util.h>
 #include <ell/queue.h>
 #include <ell/timeout.h>
 #include <ell/rtnl.h>
+#pragma GCC diagnostic pop
 
 #include <mptcpd/private/path_manager.h>
 #include <mptcpd/network_monitor.h>

--- a/lib/path_manager.c
+++ b/lib/path_manager.c
@@ -16,10 +16,13 @@
 
 #include <netinet/in.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <ell/genl.h>
 #include <ell/queue.h>
 #include <ell/util.h>  // For L_STRINGIFY needed by l_error().
 #include <ell/log.h>
+#pragma GCC diagnostic pop
 
 #include <mptcpd/path_manager.h>
 #include <mptcpd/private/path_manager.h>

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -20,10 +20,13 @@
 #include <unistd.h>
 #include <assert.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <ell/queue.h>
 #include <ell/hashmap.h>
 #include <ell/util.h>
 #include <ell/log.h>
+#pragma GCC diagnostic pop
 
 /**
  * @todo Remove this preprocessor symbol definition once support for

--- a/plugins/path_managers/addr_adv.c
+++ b/plugins/path_managers/addr_adv.c
@@ -13,8 +13,11 @@
 
 #include <errno.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <ell/util.h>  // For L_STRINGIFY needed by ELL log macros.
 #include <ell/log.h>
+#pragma GCC diagnostic pop
 
 
 #include <mptcpd/private/path_manager.h>

--- a/plugins/path_managers/sspi.c
+++ b/plugins/path_managers/sspi.c
@@ -17,9 +17,12 @@
 
 #include <netinet/in.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <ell/util.h>  // For L_STRINGIFY needed by l_error().
 #include <ell/log.h>
 #include <ell/queue.h>
+#pragma GCC diagnostic pop
 
 #include <mptcpd/network_monitor.h>
 #include <mptcpd/path_manager.h>

--- a/src/commands.c
+++ b/src/commands.c
@@ -15,9 +15,12 @@
 
 #include <string.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <ell/genl.h>
 #include <ell/util.h>  // For L_STRINGIFY needed by l_error(), etc.
 #include <ell/log.h>
+#pragma GCC diagnostic pop
 
 #include "commands.h"
 

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -21,11 +21,14 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <ell/log.h>
 #include <ell/util.h>
 #include <ell/settings.h>
 #include <ell/queue.h>
 #include <ell/string.h>
+#pragma GCC diagnostic pop
 
 #include <mptcpd/types.h>
 

--- a/src/mptcpd.c
+++ b/src/mptcpd.c
@@ -15,9 +15,12 @@
 #include <signal.h>
 #include <assert.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <ell/util.h>  // For L_STRINGIFY needed by l_error().
 #include <ell/log.h>
 #include <ell/main.h>
+#pragma GCC diagnostic pop
 
 #include <mptcpd/private/configuration.h>
 

--- a/src/netlink_pm.c
+++ b/src/netlink_pm.c
@@ -10,8 +10,11 @@
 #include <stdbool.h>
 #include <stdio.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <ell/log.h>
 #include <ell/util.h>
+#pragma GCC diagnostic pop
 
 #include "netlink_pm.h"
 

--- a/src/netlink_pm_upstream.c
+++ b/src/netlink_pm_upstream.c
@@ -15,9 +15,12 @@
 #include <errno.h>
 #include <sys/socket.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <ell/genl.h>
 #include <ell/util.h>  // For L_STRINGIFY needed by l_error(), etc.
 #include <ell/log.h>
+#pragma GCC diagnostic pop
 
 #include <mptcpd/private/mptcp_upstream.h>
 #include <mptcpd/private/netlink_pm.h>

--- a/src/path_manager.c
+++ b/src/path_manager.c
@@ -21,11 +21,14 @@
 #include <arpa/inet.h>   // For inet_ntop().
 #include <netinet/in.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <ell/genl.h>
 #include <ell/log.h>
 #include <ell/queue.h>
 #include <ell/timeout.h>
 #include <ell/util.h>
+#pragma GCC diagnostic pop
 
 #include <mptcpd/path_manager.h>
 #include <mptcpd/private/path_manager.h>

--- a/tests/plugins/noop/noop.c
+++ b/tests/plugins/noop/noop.c
@@ -7,8 +7,11 @@
  * Copyright (c) 2019-2021, Intel Corporation
  */
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <ell/util.h>  // For L_STRINGIFY needed by l_error().
 #include <ell/log.h>
+#pragma GCC diagnostic pop
 
 #ifdef HAVE_CONFIG_H
 # include <mptcpd/private/config.h>

--- a/tests/plugins/priority/one.c
+++ b/tests/plugins/priority/one.c
@@ -7,8 +7,11 @@
  * Copyright (c) 2019-2021, Intel Corporation
  */
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <ell/util.h>  // For L_STRINGIFY needed by l_error().
 #include <ell/log.h>
+#pragma GCC diagnostic pop
 
 #ifdef HAVE_CONFIG_H
 # include <mptcpd/private/config.h>

--- a/tests/plugins/priority/two.c
+++ b/tests/plugins/priority/two.c
@@ -7,8 +7,11 @@
  * Copyright (c) 2019-2021, Intel Corporation
  */
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <ell/util.h>  // For L_STRINGIFY needed by l_error().
 #include <ell/log.h>
+#pragma GCC diagnostic pop
 
 #ifdef HAVE_CONFIG_H
 # include <mptcpd/private/config.h>

--- a/tests/plugins/security/four.c
+++ b/tests/plugins/security/four.c
@@ -7,8 +7,11 @@
  * Copyright (c) 2019-2021, Intel Corporation
  */
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <ell/util.h>  // For L_STRINGIFY needed by l_error().
 #include <ell/log.h>
+#pragma GCC diagnostic pop
 
 #ifdef HAVE_CONFIG_H
 # include <mptcpd/private/config.h>

--- a/tests/plugins/security/three.c
+++ b/tests/plugins/security/three.c
@@ -7,8 +7,11 @@
  * Copyright (c) 2019-2021, Intel Corporation
  */
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <ell/util.h>  // For L_STRINGIFY needed by l_error().
 #include <ell/log.h>
+#pragma GCC diagnostic pop
 
 #ifdef HAVE_CONFIG_H
 # include <mptcpd/private/config.h>

--- a/tests/test-commands.c
+++ b/tests/test-commands.c
@@ -14,6 +14,8 @@
 #include <arpa/inet.h>
 #include <net/if.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <ell/main.h>
 #include <ell/idle.h>
 #include <ell/util.h>      // Needed by <ell/log.h>
@@ -21,6 +23,7 @@
 #include <ell/netlink.h>
 #include <ell/rtnl.h>
 #include <ell/test.h>
+#pragma GCC diagnostic pop
 
 // Internal Headers
 // -----------------

--- a/tests/test-configuration.c
+++ b/tests/test-configuration.c
@@ -7,10 +7,13 @@
  * Copyright (c) 2019, 2021, Intel Corporation
  */
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <ell/main.h>
 #include <ell/util.h>      // Needed by <ell/log.h>
 #include <ell/log.h>
 #include <ell/test.h>
+#pragma GCC diagnostic pop
 
 #include <mptcpd/private/configuration.h>  // INTERNAL!
 

--- a/tests/test-network-monitor.c
+++ b/tests/test-network-monitor.c
@@ -15,11 +15,14 @@
 #include <netinet/in.h>  // For INET_ADDRSTRLEN and INET6_ADDRSTRLEN.
 #include <net/if.h>      // For standard network interface flags.
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <ell/main.h>
 #include <ell/idle.h>
 #include <ell/util.h>      // Needed by <ell/log.h>
 #include <ell/log.h>
 #include <ell/queue.h>
+#pragma GCC diagnostic pop
 
 #include <mptcpd/network_monitor.h>
 

--- a/tests/test-path-manager.c
+++ b/tests/test-path-manager.c
@@ -9,11 +9,14 @@
 
 #include <unistd.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <ell/main.h>
 #include <ell/genl.h>
 #include <ell/timeout.h>
 #include <ell/util.h>      // Needed by <ell/log.h>
 #include <ell/log.h>
+#pragma GCC diagnostic pop
 
 #include "test-util.h"
 


### PR DESCRIPTION
ELL 0.45 and later have header files that use a trailing semicolon with
the DEFINE_CLEANUP_FUNC() macro, which is not compatible with the
"-pedantic" flag in gcc. This causes the mptcpd code to issue the
following error:

"ISO C does not allow extra ‘;’ outside of a function [-Werror=pedantic]"

Wrap the ELL includes in some pragmas to avoid this error.