### PR TITLE
tests: Fix clang initialization error.

### DIFF
--- a/tests/test-sockaddr.c
+++ b/tests/test-sockaddr.c
@@ -69,13 +69,12 @@ static void test_sockaddr_in_init(void const *test_data)
 {
         (void) test_data;
 
-        static in_addr_t const *const addr4 =
-                &test_laddr_1.sin_addr.s_addr;
-        static struct in6_addr const *const addr6 = NULL;
-        static unsigned short const port = test_laddr_1.sin_port;
+        in_addr_t const *const addr4 = &test_laddr_1.sin_addr.s_addr;
+        struct in6_addr const *const addr6 = NULL;
+        unsigned short const port = test_laddr_1.sin_port;
 
         struct sockaddr_storage addr = { .ss_family = AF_UNSPEC };
-            
+
         bool const initialized =
             mptcpd_sockaddr_storage_init(addr4, addr6, port, &addr);
 
@@ -88,13 +87,12 @@ static void test_sockaddr_in6_init(void const *test_data)
 {
         (void) test_data;
 
-        static in_addr_t const *const addr4 = NULL;
-        static struct in6_addr const *const addr6 =
-                &test_laddr_2.sin6_addr;
-        static unsigned short const port = test_laddr_2.sin6_port;
+        in_addr_t const *const addr4 = NULL;
+        struct in6_addr const *const addr6 = &test_laddr_2.sin6_addr;
+        unsigned short const port = test_laddr_2.sin6_port;
 
         struct sockaddr_storage addr = { .ss_family = AF_UNSPEC };
-            
+
         bool const initialized =
             mptcpd_sockaddr_storage_init(addr4, addr6, port, &addr);
 


### PR DESCRIPTION
The following compile-time error occurs in tests/test-sockaddr.c when
building mptcpd with clang 14:

    error: initializer element is not a compile-time constant

Drop the "static" storage qualifier as needed to address this error.