### PR TITLE
Improve mptcpd ID manager hashing.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ tests/test-cxx-build
 tests/test-id-manager
 tests/test-sockaddr
 tests/test-addr-info
+tests/test-murmur-hash
 tests/mptcpwrap-tester
 tests/*.log
 tests/*.trs

--- a/configure.ac
+++ b/configure.ac
@@ -267,6 +267,11 @@ AC_CHECK_FUNC([l_hashmap_replace],
                          [ELL has l_hashmap_replace()])])
 LIBS=$mptcpd_save_libs
 
+AC_CHECK_FUNC([getauxval],
+              [AC_DEFINE([HAVE_GETAUXVAL],
+                         [],
+                         [C library has getauxval()])])
+
 # ---------------------------------------------------------------
 # Enable additional C compiler warnings.  We do this after all
 # Autoconf tests have been run since not all autoconf macros are

--- a/include/mptcpd/Makefile.am
+++ b/include/mptcpd/Makefile.am
@@ -1,6 +1,6 @@
 ## SPDX-License-Identifier: BSD-3-Clause
 ##
-## Copyright (c) 2017-2021, Intel Corporation
+## Copyright (c) 2017-2022, Intel Corporation
 
 pkginclude_HEADERS =		\
 	addr_info.h		\
@@ -18,6 +18,7 @@ noinst_HEADERS =			\
 	private/id_manager.h		\
 	private/mptcp_org.h		\
 	private/mptcp_upstream.h	\
+	private/murmur_hash.h		\
 	private/netlink_pm.h		\
 	private/path_manager.h 		\
 	private/plugin.h		\

--- a/include/mptcpd/private/murmur_hash.h
+++ b/include/mptcpd/private/murmur_hash.h
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/**
+ * @file murmur_hash.h
+ *
+ * This file contains a customized version of the public domain
+ * MurmurHash3 code written by Austin Appleby.  Changes relative to
+ * the original:
+ *
+ * @li 128 bit hash functions were removed.  They are not needed by
+ *     mptcpd since the ELL l_hashmap expects hash values of type
+ *     @c unsigned @c int.
+ * @li The @c MurmurHash3_x86_32() function was renamed to
+ *     @c mptcpd_murmur_hash3().
+ * @li The hash value is returned as an @ @c unsigned @c int return
+ *     value instead of a @c void* function "out" parameter.
+ * @li The coding style was modified to conform to the mptcpd style.
+ *
+ * @see https://github.com/aappleby/smhasher/blob/master/src/MurmurHash3.h
+ *
+ * Copyright (c) 2022, Intel Corporation
+ */
+
+#ifndef MPTCPD_MURMUR_HASH_3_H
+#define MPTCPD_MURMUR_HASH_3_H
+
+#include <stdint.h>
+
+#include <mptcpd/export.h>
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Generate hash of @a key using the MurmurHash3 algorithm.
+ *
+ * @param[in] key  Key value to be hashed.
+ * @param[in] len  Length of @a key in bytes.
+ * @param[in] seed Initial value of hash prior to hashing @a key.
+ *
+ * @return Hash of @a key.
+ *
+ * @attention The generated hash value is not cryptographically
+ *            strong.
+ *
+ * @see https://github.com/aappleby/smhasher/blob/master/src/MurmurHash3.cpp
+ */
+MPTCPD_API unsigned int mptcpd_murmur_hash3(void const *key,
+                                            int len,
+                                            uint32_t seed);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // MPTCPD_MURMUR_HASH_3_H
+
+
+/*
+  Local Variables:
+  c-file-style: "linux"
+  End:
+*/

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,6 +1,6 @@
 ## SPDX-License-Identifier: BSD-3-Clause
 ##
-## Copyright (c) 2018-2020, Intel Corporation
+## Copyright (c) 2018-2020, 2022, Intel Corporation
 
 include $(top_srcdir)/aminclude_static.am
 
@@ -24,7 +24,8 @@ libmptcpd_la_SOURCES =		\
 	network_monitor.c	\
 	path_manager.c		\
 	plugin.c		\
-	sockaddr.c
+	sockaddr.c		\
+	murmur_hash.c
 
 #if BUILDING_DLL
 #libmptcpd_la_SOURCES += debug.c

--- a/lib/id_manager.c
+++ b/lib/id_manager.c
@@ -4,7 +4,7 @@
  *
  * @brief Map of network address to MPTCP address ID.
  *
- * Copyright (c) 2020, 2021, Intel Corporation
+ * Copyright (c) 2020-2022, Intel Corporation
  */
 
 #ifdef HAVE_CONFIG_H
@@ -13,8 +13,13 @@
 
 #include <assert.h>
 #include <stdint.h>
+#include <time.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
+
+#ifdef HAVE_GETAUXVAL
+# include <sys/auxv.h>
+#endif // HAVE_GETAUXVAL
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
@@ -23,6 +28,7 @@
 #include <ell/util.h>
 #pragma GCC diagnostic pop
 
+#include <mptcpd/private/murmur_hash.h>
 #include <mptcpd/private/id_manager.h>
 #include <mptcpd/id_manager.h>
 
@@ -35,6 +41,26 @@
 /// Maximum MPTCP address ID.
 #define MPTCPD_MAX_ID UINT8_MAX
 
+
+/**
+ * @brief MurmurHash3 seed value.
+ *
+ * @note This could be tied to each @c mptcpd_idm instance so that the
+ *       seed value wouldn't shared between multiple mptcpd_idm
+ *       instances but the only way to pass the seed value to the
+ *       mptcpd MurmurHash3 hash function through the ELL @c l_hashmap
+ *       interface would be to make it a part of the key, such as
+ *       through a convenience @c struct.  That would double the size
+ *       of the key on 64 bit platforms (sizeof(struct sockaddr*) +
+ *       sizeof(uint32_t) + padding).  That may not be a problem for
+ *       the common case since most platforms would not have many
+ *       local addresses, meaning the larger key size would not impact
+ *       the run-time memory footprint by much.  Furthermore, it is
+ *       unlikely that such a global seed value shared between
+ *       @c mptcpd_idm instances would be a problem since each
+ *       @c mptcpd_idm insance would have its own @c l_hashmap.
+ */
+static uint32_t _idm_hash_seed = 0;
 
 /**
  * @struct mptcpd_idm
@@ -63,29 +89,17 @@ struct mptcpd_idm
 static inline unsigned int
 mptcpd_hash_sockaddr_in(struct sockaddr_in const *sa)
 {
-        /**
-         * @todo This hash function is rather trivial.  If collisions
-         *       end up being a concern we may want to look into a
-         *       better hash algorithm, such as MurmurHash.
-         */
-        return sa->sin_addr.s_addr;
+        return mptcpd_murmur_hash3(&sa->sin_addr.s_addr,
+                                   sizeof(sa->sin_addr.s_addr),
+                                   _idm_hash_seed);
 }
 
 static inline unsigned int
 mptcpd_hash_sockaddr_in6(struct sockaddr_in6 const *sa)
 {
-        /**
-         * @todo This hash function is rather trivial.  If collisions
-         *       end up being a concern we may want to look into a
-         *       better hash algorithm, such as MurmurHash.
-         */
-        // Hash based on the last 4 bytes of the IPv6 address.
-        static size_t const offset =
-                sizeof(sa->sin6_addr.s6_addr) - sizeof(unsigned int) - 1;
-
-        uint8_t const *const addr6 = sa->sin6_addr.s6_addr;
-
-        return *((unsigned int *) (addr6 + offset));
+        return mptcpd_murmur_hash3(sa->sin6_addr.s6_addr,
+                                   sizeof(sa->sin6_addr.s6_addr),
+                                   _idm_hash_seed);
 }
 
 static unsigned int mptcpd_hash_sockaddr(void const *p)
@@ -201,6 +215,22 @@ struct mptcpd_idm *mptcpd_idm_create(void)
             || !l_hashmap_set_key_free_function(idm->map, l_free)) {
                 mptcpd_idm_destroy(idm);
                 idm = NULL;
+        }
+
+        if (_idm_hash_seed == 0) {
+                _idm_hash_seed = (uint32_t) time(NULL);
+
+#ifdef HAVE_GETAUXVAL
+                /*
+                  Further randomize the hash seed value with
+                  process-specific random data supplied by the kernel,
+                  skipping the canary in the first half.
+                */
+                unsigned long const addr =
+                        getauxval(AT_RANDOM) + sizeof(void *);
+
+                _idm_hash_seed ^= (uint32_t) *((unsigned long *) addr);
+#endif  // HAVE_GETAUXVAL
         }
 
         return idm;

--- a/lib/murmur_hash.c
+++ b/lib/murmur_hash.c
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/**
+ * @file murmur_hash.c
+ *
+ * This file contains a customized version of the public domain
+ * MurmurHash3 code written by Austin Appleby.  Changes relative to
+ * the original:
+ *
+ * @li 128 bit hash functions were removed.  They are not needed by
+ *     mptcpd since the ELL l_hashmap expects hash values of type
+ *     @c unsigned @c int.
+ * @li The @c MurmurHash3_x86_32() function was renamed to
+ *     @c mptcpd_murmur_hash3().
+ * @li The hash value is returned as an @c unsigned @c int return
+ *     value instead of a function "out" parameter of type @c void*.
+ * @li The only compiler-specific support left in place is for gcc and
+ *     clang.
+ * @li The coding style was modified to conform to the mptcpd style.
+ * @li gcc "implicit fallthrough" warnings for switch statement were
+ *     silenced.
+ *
+ * @see https://github.com/aappleby/smhasher/blob/master/src/MurmurHash3.cpp
+ *
+ * Copyright (c) 2022, Intel Corporation
+ */
+
+#include "murmur_hash.h"
+
+#ifdef __GNUC__
+#  define FORCE_INLINE inline __attribute__((always_inline))
+
+/*
+  Silence gcc "implicit fallthrough" warnings for switch statement
+  cases below.
+*/
+#  define FALLTHROUGH __attribute__((fallthrough))
+#else
+#  define FORCE_INLINE inline
+#  define FALLTHROUGH
+#endif  // __GNUC__
+
+
+//------------------------------------------------------------------------
+
+#define FORCE_INLINE inline __attribute__((always_inline))
+
+static inline uint32_t rotl32(uint32_t x, int8_t r)
+{
+        return (x << r) | (x >> (32 - r));
+}
+
+//------------------------------------------------------------------------
+// Block read - if your platform needs to do endian-swapping or can only
+// handle aligned reads, do the conversion here
+
+static FORCE_INLINE uint32_t getblock32 (uint32_t const *p, int i)
+{
+        return p[i];
+}
+
+//------------------------------------------------------------------------
+// Finalization mix - force all bits of a hash block to avalanche
+
+static FORCE_INLINE uint32_t fmix32(uint32_t h)
+{
+        h ^= h >> 16;
+        h *= 0x85ebca6b;
+        h ^= h >> 13;
+        h *= 0xc2b2ae35;
+        h ^= h >> 16;
+
+        return h;
+}
+
+//------------------------------------------------------------------------
+
+unsigned int mptcpd_murmur_hash3(void const *key,
+                                 int len,
+                                 uint32_t seed)
+{
+        uint8_t const *const data = (uint8_t const *) key;
+        int const nblocks = len / 4;
+
+        uint32_t h1 = seed;
+
+        uint32_t const c1 = 0xcc9e2d51;
+        uint32_t const c2 = 0x1b873593;
+
+        //----------
+        // body
+
+        uint32_t const *const blocks =
+                (uint32_t const *)(data + nblocks * 4);
+
+        for (int i = -nblocks; i; i++) {
+                uint32_t k1 = getblock32(blocks, i);
+
+                k1 *= c1;
+                k1 = rotl32(k1, 15);
+                k1 *= c2;
+
+                h1 ^= k1;
+                h1 = rotl32(h1, 13);
+                h1 = h1 * 5 + 0xe6546b64;
+        }
+
+        //----------
+        // tail
+
+        uint8_t const *const tail = (uint8_t const *)(data + nblocks * 4);
+
+        uint32_t k1 = 0;
+
+        switch (len & 3) {
+        case 3: k1 ^= tail[2] << 16; FALLTHROUGH;
+        case 2: k1 ^= tail[1] << 8;  FALLTHROUGH;
+        case 1: k1 ^= tail[0];
+                k1 *= c1; k1 = rotl32(k1,15); k1 *= c2; h1 ^= k1;
+        };
+
+        //----------
+        // finalization
+
+        h1 ^= len;
+
+        h1 = fmix32(h1);
+
+        return h1;
+}
+
+
+/*
+  Local Variables:
+  c-file-style: "linux"
+  End:
+*/

--- a/lib/murmur_hash.c
+++ b/lib/murmur_hash.c
@@ -15,6 +15,7 @@
  *     value instead of a function "out" parameter of type @c void*.
  * @li The only compiler-specific support left in place is for gcc and
  *     clang.
+ * @li Declare @c inline functions as @c static @c inline.
  * @li The coding style was modified to conform to the mptcpd style.
  * @li gcc "implicit fallthrough" warnings for switch statement were
  *     silenced.
@@ -48,17 +49,25 @@ static inline uint32_t rotl32(uint32_t x, int8_t r)
 }
 
 //------------------------------------------------------------------------
-// Block read - if your platform needs to do endian-swapping or can only
-// handle aligned reads, do the conversion here
 
+/**
+ * @brief Block read.
+ *
+ * If your platform needs to do endian-swapping or can only handle
+ * aligned reads, do the conversion here.
+ */
 static FORCE_INLINE uint32_t getblock32 (uint32_t const *p, int i)
 {
         return p[i];
 }
 
 //------------------------------------------------------------------------
-// Finalization mix - force all bits of a hash block to avalanche
 
+/**
+ * @brief Finalization mix.
+ *
+ * Force all bits of a hash block to avalanche.
+ */
 static FORCE_INLINE uint32_t fmix32(uint32_t h)
 {
         h ^= h >> 16;

--- a/lib/murmur_hash.c
+++ b/lib/murmur_hash.c
@@ -24,7 +24,7 @@
  * Copyright (c) 2022, Intel Corporation
  */
 
-#include "murmur_hash.h"
+#include <mptcpd/private/murmur_hash.h>
 
 #ifdef __GNUC__
 #  define FORCE_INLINE inline __attribute__((always_inline))

--- a/lib/murmur_hash.c
+++ b/lib/murmur_hash.c
@@ -42,8 +42,6 @@
 
 //------------------------------------------------------------------------
 
-#define FORCE_INLINE inline __attribute__((always_inline))
-
 static inline uint32_t rotl32(uint32_t x, int8_t r)
 {
         return (x << r) | (x >> (32 - r));

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -29,7 +29,8 @@ check_PROGRAMS =		\
 	test-configuration	\
 	test-id-manager		\
 	test-sockaddr		\
-	test-addr-info
+	test-addr-info		\
+	test-murmur-hash
 
 noinst_PROGRAMS = mptcpwrap-tester
 
@@ -110,6 +111,12 @@ test_sockaddr_LDADD =				\
 
 test_addr_info_SOURCES = test-addr-info.c
 test_addr_info_LDADD =				\
+	$(top_builddir)/lib/libmptcpd.la	\
+	$(ELL_LIBS)				\
+	$(CODE_COVERAGE_LIBS)
+
+test_murmur_hash_SOURCES = test-murmur-hash.c
+test_murmur_hash_LDADD =			\
 	$(top_builddir)/lib/libmptcpd.la	\
 	$(ELL_LIBS)				\
 	$(CODE_COVERAGE_LIBS)

--- a/tests/test-murmur-hash.c
+++ b/tests/test-murmur-hash.c
@@ -63,9 +63,14 @@ static void test_hash_32(void const *test_data)
         assert(hash3 != hash2);
         assert(hash3 != hash1);
 
+        uint8_t a[31] = { 1, 2, 3 };
+        unsigned int const hash4 =
+            mptcpd_murmur_hash3(a, sizeof(a), seed);
+
         l_info("hash1: 0x%x", hash1);
         l_info("hash2: 0x%x", hash2);
         l_info("hash3: 0x%x", hash3);
+        l_info("hash4: 0x%x", hash4);
 }
 
 int main(int argc, char *argv[])

--- a/tests/test-murmur-hash.c
+++ b/tests/test-murmur-hash.c
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/**
+ * @file test-murmur-hash.c
+ *
+ * @brief mptcpd MurmurHash3 test.
+ *
+ * Copyright (c) 2022, Intel Corporation
+ */
+
+#include <stdint.h>
+#include <stddef.h>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#include <ell/util.h>  // Needed by <ell/log.h>.
+#include <ell/log.h>
+#include <ell/test.h>
+#pragma GCC diagnostic pop
+
+#include <mptcpd/private/murmur_hash.h>
+
+#undef NDEBUG
+#include <assert.h>
+
+
+static void test_hash_32(void const *test_data)
+{
+        (void) test_data;
+
+        /*
+          This test is not meant to test the MurmurHash3 algorithm
+          itself.  It is only meant to perform a black box test of
+          mptcpd_murmur_hash3() since an extensive test suite for the
+          MurmurHash3 algorithm already exists upstream.
+          See: https://github.com/aappleby/smhasher
+        */
+
+        uint32_t const k1 = 0x010200C0;
+        uint32_t const k2 = k1 + 1;
+        uint8_t  const k3[16] = {
+            [0]  = 0x20,
+            [1]  = 0x01,
+            [2]  = 0X0D,
+            [3]  = 0xB8,
+            [14] = 0x01,
+            [15] = 0x02
+        };
+
+        uint32_t const seed = 0xc0ffee;
+
+        unsigned int const hash1 =
+            mptcpd_murmur_hash3(&k1, sizeof(k1), seed);
+        assert(hash1 != 0);
+
+        unsigned int const hash2 =
+            mptcpd_murmur_hash3(&k2, sizeof(k2), seed);
+        assert(hash2 != 0);
+        assert(hash2 != hash1);
+
+        unsigned int const hash3 =
+            mptcpd_murmur_hash3(k3, sizeof(k3), seed);
+        assert(hash3 != 0);
+        assert(hash3 != hash2);
+        assert(hash3 != hash1);
+
+        l_info("hash1: 0x%x", hash1);
+        l_info("hash2: 0x%x", hash2);
+        l_info("hash3: 0x%x", hash3);
+}
+
+int main(int argc, char *argv[])
+{
+        l_log_set_stderr();
+
+        l_test_init(&argc, &argv);
+
+        l_test_add("test MurmurHash3 (x86_32)", test_hash_32, NULL);
+
+        return l_test_run();
+}
+
+
+/*
+  Local Variables:
+  c-file-style: "linux"
+  End:
+*/


### PR DESCRIPTION
Replace the existing trivial `mptcp_idm` key hashing with a hash based on the much better public domain [MurmurHash3](https://github.com/aappleby/smhasher/blob/master/src/MurmurHash3.cpp) implementation found in the newly added `mptcpd_murmur_hash3()` function.

Changes in mptcpd's version of MurmurHash3 include the folliowing:

* 128 bit hash functions were removed.  They are not needed by mptcpd since the ELL l_hashmap expects hash values of type `unsigned int.`
* The `MurmurHash3_x86_32()` function was renamed to `mptcpd_murmur_hash3()`.
* The hash value is returned as an unsigned int return value instead of a function "_out_" parameter of type `void*`.
* The only compiler-specific support left in place is for gcc and clang.
* Declare `inline` functions as `static inline`.
* The coding style was modified to conform to the [mptcpd style](https://github.com/intel/mptcpd/blob/master/CONTRIBUTING.md).
* gcc "implicit fallthrough" warnings for switch statement were silenced by leveraging the appropriate [gcc statement attribute](https://gcc.gnu.org/onlinedocs/gcc/Statement-Attributes.html).
