### PR TITLE
configuration: Fix use-after-free in merged configuration for load-plugins

### DIFF
--- a/src/configuration.c
+++ b/src/configuration.c
@@ -758,7 +758,7 @@ static bool merge_config(struct mptcpd_config       *dst,
                 while (entry) {
                         l_queue_push_tail(
                                 (struct l_queue *) dst->plugins_to_load,
-                                entry->data);
+                                l_strdup(entry->data));
 
                         entry = entry->next;
                 }


### PR DESCRIPTION
The section of merge_config() that copies entries from one
plugins_to_load queue to another was copying string pointers from one to
the other. When the source queue was freed, the string pointers in the
destination queue became invalid.

This manifested as garbage strings for the plugins_to_load value if the
load-plugins line was used in mptcpd.conf

To fix, populate the destination queue entries with l_strdup()'d
strings.