### PR TITLE
configuration: Fix addr/notify flag string leaks.

### DIFF
--- a/src/configuration.c
+++ b/src/configuration.c
@@ -4,7 +4,7 @@
  *
  * @brief Mptcpd configuration parser implementation.
  *
- * Copyright (c) 2017-2021, Intel Corporation
+ * Copyright (c) 2017-2022, Intel Corporation
  */
 
 #ifdef HAVE_CONFIG_H
@@ -574,8 +574,11 @@ static void parse_config_addr_flags(struct mptcpd_config *config,
                                       group,
                                       "addr-flags");
 
-        if (addr_flags != NULL)
+        if (addr_flags != NULL) {
                 config->addr_flags = addr_flags_from_string(addr_flags);
+
+                l_free(addr_flags);
+        }
 }
 
 static void parse_config_notify_flags(struct mptcpd_config *config,
@@ -590,8 +593,11 @@ static void parse_config_notify_flags(struct mptcpd_config *config,
                                       group,
                                       "notify-flags");
 
-        if (notify_flags != NULL)
+        if (notify_flags != NULL) {
                 config->notify_flags = notify_flags_from_string(notify_flags);
+
+                l_free(notify_flags);
+        }
 }
 
 static void parse_config_default_plugin(struct mptcpd_config *config,


### PR DESCRIPTION
Fix memory leaks that occured when parsing the "`addr-flags`" and
"`notify-flags`" entries in the mptcpd configuration file.  The string
returned from the ELL `l_settings_get_string()` function is dynamically
allocated and must be deallocated with `l_free()`.

Reported-by: Mat Martineau <mathew.j.martineau@linux.intel.com>