### PR TITLE
network_monitor: Make test addrs static constants.

### DIFF
--- a/lib/network_monitor.c
+++ b/lib/network_monitor.c
@@ -37,6 +37,7 @@
 #include <mptcpd/private/sockaddr.h>
 #include <mptcpd/network_monitor.h>
 
+
 // See IETF RFC 3849: IPv6 Address Prefix Reserved for Documentation.
 // 2001:DB8::/32
 static struct in6_addr const test_net_v6 = {
@@ -1010,13 +1011,13 @@ static void check_default_route(struct nm_addr_info *ai)
         mptcpd_addr_get(ai);
 
         if (l_netlink_send(ai->nm->rtnl,
-            RTM_GETROUTE,
-            0,
-            &store,
-            buf - (char *)&store,
-            handle_rtm_getroute,
-            ai,
-            NULL) == 0) {
+                           RTM_GETROUTE,
+                           0,
+                           &store,
+                           buf - (char *) &store,
+                           handle_rtm_getroute,
+                           ai,
+                           NULL) == 0) {
                 l_debug("Route lookup failed");
                 mptcpd_addr_put(ai);
         }

--- a/lib/network_monitor.c
+++ b/lib/network_monitor.c
@@ -34,12 +34,18 @@
 #pragma GCC diagnostic pop
 
 #include <mptcpd/private/path_manager.h>
+#include <mptcpd/private/sockaddr.h>
 #include <mptcpd/network_monitor.h>
 
 // See IETF RFC 3849: IPv6 Address Prefix Reserved for Documentation.
 // 2001:DB8::/32
-static struct in6_addr test_net_v6 = { .s6_addr = {0x20, 0x01, 0x0d, 0xb8, } };
-static struct in_addr test_net_v4;
+static struct in6_addr const test_net_v6 = {
+        .s6_addr = {0x20, 0x01, 0x0d, 0xb8, } };
+
+// See IETF RFC 5737: IPv4 Address Blocks Reserved for Documentation.
+static struct in_addr const test_net_v4 = {
+        .s_addr = MPTCPD_CONSTANT_HTONL(0xc0000201) };
+
 // -------------------------------------------------------------------
 
 /**
@@ -1536,9 +1542,6 @@ bool mptcpd_nm_register_ops(struct mptcpd_nm *nm,
 {
         if (nm == NULL || ops == NULL)
                 return false;
-
-        // See IETF RFC 5737: IPv4 Address Blocks Reserved for Documentation.
-        test_net_v4.s_addr = htonl(0xc0000201);
 
         if (ops->new_interface       == NULL
             && ops->update_interface == NULL


### PR DESCRIPTION
Make the mptcpd network monitor IPv4 and IPv6 "test net" addresses used for default route checks `static` constants to make sure they are initialized at compile-time instead of run-time.
    
The `MPTCPD_CONSTANT_HTONL()` macro was used to allow the test IPv4 address to be initialized at compile-time.  This also change also removes the re-initialization of the IPv4 test net address each time mptcpd network monitor operations are registered.
    
Pre-change object file size (-O2 optimization):
```
text    data     bss     dec     hex filename
10045     232       4   10281    2829 libmptcpd_la-network_monitor.o
```
Post-change object file size (-O2 optimization):
```
text    data     bss     dec     hex filename
10060     216       0   10276    2824 libmptcpd_la-network_monitor.o
```
