### PR TITLE
tests: net-mon: do not fail when iface has no addr

### DIFF
--- a/tests/test-network-monitor.c
+++ b/tests/test-network-monitor.c
@@ -112,10 +112,11 @@ static void check_interface(struct mptcpd_interface const *i, void *data)
                 i->flags,
                 i->name);
 
-        assert(l_queue_length(i->addrs) > 0);
-
-        l_debug("  addrs:");
-        l_queue_foreach(i->addrs, dump_addr, NULL);
+        /* Ifaces can have no addresses, e.g. if attached to a bridge. */
+        if (l_queue_length(i->addrs) > 0) {
+                l_debug("  addrs:");
+                l_queue_foreach(i->addrs, dump_addr, NULL);
+        }
 
         /*
           Only network interfaces that are up and running should be


### PR DESCRIPTION
This test currently fails if it detects an active interface without any
IPv4 or v6 addresses.

This situation is valid, e.g. when an interface is attached to a bridge.
This bridge would have attached IP addresses but not the interface.

Fixes: c7e2201 ("mptcpd 0.1a: Initial alpha release.")
Reported-by: Adam Borowski
Signed-off-by: Matthieu Baerts