### PR TITLE
Mark network monitor factory functions as private.

### DIFF
--- a/include/mptcpd/Makefile.am
+++ b/include/mptcpd/Makefile.am
@@ -22,6 +22,7 @@ noinst_HEADERS =			\
 	private/mptcp_upstream.h	\
 	private/murmur_hash.h		\
 	private/netlink_pm.h		\
+	private/network_monitor.h	\
 	private/path_manager.h 		\
 	private/plugin.h		\
 	private/sockaddr.h

--- a/include/mptcpd/network_monitor.h
+++ b/include/mptcpd/network_monitor.h
@@ -4,7 +4,7 @@
  *
  * @brief mptcpd network device monitoring.
  *
- * Copyright (c) 2017-2020, Intel Corporation
+ * Copyright (c) 2017-2022, Intel Corporation
  */
 
 #ifndef MPTCPD_NETWORK_MONITOR_H
@@ -12,6 +12,7 @@
 
 #include <mptcpd/export.h>
 
+#include <stdbool.h>
 #include <net/if.h>  // For IF_NAMESIZE.
 
 #ifdef __cplusplus
@@ -139,30 +140,6 @@ struct mptcpd_nm_ops
                                struct sockaddr const *sa,
                                void *user_data);
 };
-
-/**
- * @brief Create a network monitor.
- *
- * @param[in] flags            flags controlling address notification,
- *                             any of:
- *                             MPTCPD_NOTIFY_FLAG_EXISTING,,
- *                             MPTCPD_NOTIFY_FLAG_SKIP_LL,
- *                             MPTCPD_NOTIFY_FLAG_SKIP_HOST
- *
- * @todo As currently implemented, one could create multiple network
- *       monitors.  Is that useful?
- *
- * @return Pointer to new network monitor on success.  @c NULL on
- *         failure.
- */
-MPTCPD_API struct mptcpd_nm *mptcpd_nm_create(uint32_t flags);
-
-/**
- * @brief Destroy a network monitor.
- *
- * @param[in,out] nm Network monitor to be destroyed.
- */
-MPTCPD_API void mptcpd_nm_destroy(struct mptcpd_nm *nm);
 
 /**
  * @brief Network monitor iteration function type.

--- a/include/mptcpd/private/network_monitor.h
+++ b/include/mptcpd/private/network_monitor.h
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/**
+ * @file private/network_monitor.h
+ *
+ * @brief mptcpd network device monitoring - internal API.
+ *
+ * Copyright (c) 2017-2022, Intel Corporation
+ */
+
+#ifndef MPTCPD_PRIVATE_NETWORK_MONITOR_H
+#define MPTCPD_PRIVATE_NETWORK_MONITOR_H
+
+#include <mptcpd/export.h>
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct mptcpd_nm;
+
+/**
+ * @name Mptcpd Network Monitor Flags
+ *
+ * Flags controlling address notification in the mptcpd network
+ * monitor.  Pass to @c mptcpd_nm_create().
+ */
+///@{
+/// Notify even the addresses already existing at startup-time.
+#define MPTCPD_NOTIFY_FLAG_EXISTING (1U << 0)
+
+/// Ignore link-local addresses.
+#define MPTCPD_NOTIFY_FLAG_SKIP_LL (1U << 1)
+
+/// Ignore host (loopback) addresses.
+#define MPTCPD_NOTIFY_FLAG_SKIP_HOST (1U << 2)
+
+/**
+ * Notify address only if a default route is available from the given
+ * interface.
+ */
+#define MPTCPD_NOTIFY_FLAG_ROUTE_CHECK (1U << 3)
+///@}
+
+/**
+ * @brief Create a network monitor.
+ *
+ * @param[in] flags Flags controlling address notification, any of:
+ *                  MPTCPD_NOTIFY_FLAG_EXISTING,
+ *                  MPTCPD_NOTIFY_FLAG_SKIP_LL,
+ *                  MPTCPD_NOTIFY_FLAG_SKIP_HOST
+ *
+ * @todo As currently implemented, one could create multiple network
+ *       monitors.  Is that useful?
+ *
+ * @return Pointer to new network monitor on success.  @c NULL on
+ *         failure.
+ */
+MPTCPD_API struct mptcpd_nm *mptcpd_nm_create(uint32_t flags);
+
+/**
+ * @brief Destroy a network monitor.
+ *
+ * @param[in,out] nm Network monitor to be destroyed.
+ */
+MPTCPD_API void mptcpd_nm_destroy(struct mptcpd_nm *nm);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // MPTCPD_PRIVATE_NETWORK_MONITOR_H
+
+
+/*
+  Local Variables:
+  c-file-style: "linux"
+  End:
+*/

--- a/include/mptcpd/types.h
+++ b/include/mptcpd/types.h
@@ -60,18 +60,6 @@ typedef uint32_t mptcpd_flags_t;
 #define MPTCPD_ADDR_FLAG_BACKUP  (1U << 2)
 ///@}
 
-/// Notify even the addresses already existing at startup-time.
-#define MPTCPD_NOTIFY_FLAG_EXISTING  (1U << 0)
-
-/// Ignore link-local addresses.
-#define MPTCPD_NOTIFY_FLAG_SKIP_LL (1U << 1)
-
-/// Ignore host (loopback) addresses.
-#define MPTCPD_NOTIFY_FLAG_SKIP_HOST (1U << 2)
-
-/// Notify address only if a default route is available from the given interface
-#define MPTCPD_NOTIFY_FLAG_ROUTE_CHECK (1U << 3)
-
 /**
  * @enum mptcpd_limit_types
  *

--- a/lib/network_monitor.c
+++ b/lib/network_monitor.c
@@ -35,7 +35,9 @@
 
 #include <mptcpd/private/path_manager.h>
 #include <mptcpd/private/sockaddr.h>
+#include <mptcpd/private/network_monitor.h>
 #include <mptcpd/network_monitor.h>
+
 
 
 // See IETF RFC 3849: IPv6 Address Prefix Reserved for Documentation.

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -33,6 +33,7 @@
 #include <mptcpd/types.h>
 
 #include <mptcpd/private/configuration.h>
+#include <mptcpd/private/network_monitor.h>
 
 #ifdef HAVE_CONFIG_H
 # include <mptcpd/private/config.h>
@@ -125,7 +126,6 @@ static struct tok_entry const addr_flags_toks[] = {
         { 0, NULL },
 };
 
-
 /**
  * @brief Converts the flags into a string representation.
  *
@@ -169,10 +169,10 @@ static char const *addr_flags_string(uint32_t flags,
         return flags_string(addr_flags_toks, flags, str, len);
 }
 
-struct tok_entry const notify_flags_toks[] = {
-        { MPTCPD_NOTIFY_FLAG_EXISTING, "existing" },
-        { MPTCPD_NOTIFY_FLAG_SKIP_LL, "skip_link_local" },
-        { MPTCPD_NOTIFY_FLAG_SKIP_HOST, "skip_loopback" },
+static struct tok_entry const notify_flags_toks[] = {
+        { MPTCPD_NOTIFY_FLAG_EXISTING,    "existing" },
+        { MPTCPD_NOTIFY_FLAG_SKIP_LL,     "skip_link_local" },
+        { MPTCPD_NOTIFY_FLAG_SKIP_HOST,   "skip_loopback" },
         { MPTCPD_NOTIFY_FLAG_ROUTE_CHECK, "check_route" },
         { 0, NULL },
 };

--- a/src/path_manager.c
+++ b/src/path_manager.c
@@ -33,6 +33,7 @@
 #include <mptcpd/path_manager.h>
 #include <mptcpd/private/path_manager.h>
 #include <mptcpd/private/plugin.h>
+#include <mptcpd/private/network_monitor.h>
 #include <mptcpd/network_monitor.h>
 #include <mptcpd/private/id_manager.h>
 #include <mptcpd/id_manager.h>

--- a/tests/test-cxx-build.cpp
+++ b/tests/test-cxx-build.cpp
@@ -17,6 +17,7 @@
 #include <mptcpd/network_monitor.h>
 #include <mptcpd/plugin.h>
 
+#include <mptcpd/private/network_monitor.h>
 #include <mptcpd/private/plugin.h>
 
 #include "test-plugin.h"

--- a/tests/test-network-monitor.c
+++ b/tests/test-network-monitor.c
@@ -24,6 +24,7 @@
 #include <ell/queue.h>
 #pragma GCC diagnostic pop
 
+#include <mptcpd/private/network_monitor.h>
 #include <mptcpd/network_monitor.h>
 
 #undef NDEBUG


### PR DESCRIPTION
Move `mptcpd_nm_create()`,  `mptcpd_nm_destroy()`, and related notify
flags to a new `<mptcpd/private/network_monitor.h>` header.  They are
only meant for internal mptcpd use.