### PR TITLE
network_monitor: Fix potential NULL dereference.

### DIFF
--- a/lib/network_monitor.c
+++ b/lib/network_monitor.c
@@ -219,6 +219,9 @@ static void mptcpd_addr_cancel_timeout(struct nm_addr_info *ai)
  */
 static void mptcpd_addr_put(void *data)
 {
+        if (data == NULL)
+                return;
+
         struct nm_addr_info *const ai = data;
         if (--ai->count == 0) {
                 mptcpd_addr_cancel_timeout(ai);


### PR DESCRIPTION
Correct a potential NULL pointer dereference when cleaning up resources in the case of a failed attempt to track a network address.

Fixes #230.