### PR TITLE
src: Set MPTCP_PM_ADDR_FLAG_SIGNAL as needed.

### DIFF
--- a/include/mptcpd/path_manager.h
+++ b/include/mptcpd/path_manager.h
@@ -229,7 +229,8 @@ MPTCPD_API int mptcpd_pm_remove_subflow(
  * @param[in] addr  Local IP address and port to be advertised
  *                  through the MPTCP protocol @c ADD_ADDR
  *                  option.  The port is optional, and is
- *                  ignored if it is zero.
+ *                  ignored if it is zero.  A non-zero port implies
+ *                  @c MPTCPD_ADDR_FLAG_SIGNAL in @a flags.
  * @param[in] id    MPTCP local address ID.
  * @param[in] flags Bitset of MPTCP flags associated with the network
  *                  address, e.g. @c MPTCPD_ADDR_FLAG_SUBFLOW @c |
@@ -341,7 +342,8 @@ MPTCPD_API int mptcpd_kpm_get_limits(struct mptcpd_pm *pm,
  * @brief Set MPTCP flags for a local IP address.
  *
  * @param[in] pm    The mptcpd path manager object.
- * @param[in] addr  Local IP address.
+ * @param[in] addr  Local IP address.  A non-zero port implies
+ *                  @c MPTCPD_ADDR_FLAG_SIGNAL in @a flags.
  * @param[in] flags Flags to be associated with @a addr.
  *
  * @return @c 0 if operation was successful. -1 or @c errno otherwise.

--- a/src/netlink_pm_upstream.c
+++ b/src/netlink_pm_upstream.c
@@ -1073,6 +1073,14 @@ static int upstream_set_flags(struct mptcpd_pm *pm,
               Flags
          */
 
+        /*
+          The MPTCP_PM_ADDR_FLAG_SIGNAL flag is required when a port
+          is specified.  Make sure it is set.
+        */
+        uint16_t const port = mptcpd_get_port_number(addr);
+        if (port != 0)
+                flags |= MPTCP_PM_ADDR_FLAG_SIGNAL;
+
         struct addr_info info = {
                 .addr  = addr,
                 .flags = flags


### PR DESCRIPTION
The `MPTCP_PM_ADDR_FLAG_SIGNAL` flag is required when a port is specified.  Make sure it is set when setting flags for the given network address through through `mptcpd_kpm_set_limits()`.

This also corrects an invalid argument (`EINVAL`) error exhibited by the `test-commands` unit test.