### PR TITLE
Correct test-commands unit test failures.

### DIFF
--- a/tests/test-commands.c
+++ b/tests/test-commands.c
@@ -628,7 +628,9 @@ static void run_tests(void *user_data)
         t->tests_called = true;
 }
 
-void set_new_limit(uint32_t *limit, uint32_t old_limit, uint32_t offset)
+static void set_new_limit(uint32_t *limit,
+                          uint32_t old_limit,
+                          uint32_t offset)
 {
         assert(limit != NULL);
         assert(offset > 0);

--- a/tests/test-commands.c
+++ b/tests/test-commands.c
@@ -129,7 +129,7 @@ static uint32_t max_addrs;
 static uint32_t max_subflows;
 
 // MPTCP resource limit offsets applied to the old ones.
-static uint32_t const absolute_max_limit = 8;  // Hard-coded in the kernel
+static uint32_t const absolute_max_limit = 8;  // MPTCP_PM_ADDR_MAX
 static uint32_t const max_addrs_offset = 3;
 static uint32_t const max_subflows_offset = 5;
 
@@ -634,6 +634,7 @@ static void set_new_limit(uint32_t *limit,
 {
         assert(limit != NULL);
         assert(offset > 0);
+        assert(old_limit <= absolute_max_limit);
 
         // Do not exceed kernel hard-coded max.
         if (absolute_max_limit - old_limit >= offset)

--- a/tests/test-commands.c
+++ b/tests/test-commands.c
@@ -714,10 +714,10 @@ static void setup_tests (void *user_data)
         l_test_add("add_addr - kernel",    test_add_addr_kernel,    info);
         l_test_add("get_addr",             test_get_addr,           info);
         l_test_add("dump_addrs",           test_dump_addrs,         info);
+        l_test_add("set_flags",            test_set_flags,          info);
         l_test_add("remove_addr - kernel", test_remove_addr_kernel, info);
         l_test_add("set_limits",           test_set_limits,         info);
         l_test_add("get_limits",           test_get_limits,         info);
-        l_test_add("set_flags",            test_set_flags,          info);
         l_test_add("flush_addrs",          test_flush_addrs,        info);
 
         // User space path manager tests.

--- a/tests/test-commands.c
+++ b/tests/test-commands.c
@@ -634,9 +634,10 @@ void set_new_limit(uint32_t *limit, uint32_t old_limit, uint32_t offset)
         assert(offset > 0);
 
         // Do not exceed kernel hard-coded max.
-        assert(absolute_max_limit - old_limit >= offset);
-
-        *limit = old_limit + offset;
+        if (absolute_max_limit - old_limit >= offset)
+                *limit = old_limit + offset;
+        else
+                *limit = absolute_max_limit;
 }
 
 static void get_old_limits_callback(struct mptcpd_limit const *limits,

--- a/tests/test-commands.c
+++ b/tests/test-commands.c
@@ -672,6 +672,12 @@ static void get_old_limits_callback(struct mptcpd_limit const *limits,
 
 static void complete_setup(struct mptcpd_pm *pm, void *user_data)
 {
+        /**
+         * @note There is a chicken-and-egg problem here since we're
+         *       relying on mptcpd_kpm_get_limits() to get the MPTCP
+         *       limits at test start even though we're actually
+         *       testing this function in one of the test cases.
+         */
         int const result = mptcpd_kpm_get_limits(pm,
                                                  get_old_limits_callback,
                                                  user_data);

--- a/tests/test-commands.c
+++ b/tests/test-commands.c
@@ -836,7 +836,7 @@ static void idle_callback(struct l_idle *idle, void *user_data)
           This gives the mptcpd path manager enough time to process
           replies from commands like get_addr, dump_addrs, and get_limits.
         */
-        static int const trigger_count = 10;
+        static int const trigger_count = 40;
 
         /*
           Maximum number of ELL event loop iterations.


### PR DESCRIPTION
The `test-commands` unit test fails due to a number of issues:

* It incorrectly assumes the `add_addr_accepted` and `subflows` (see [ip-mptcp(8)](https://man7.org/linux/man-pages/man8/ip-mptcp.8.html)) MPTCP resource limits are zero at test start, which causes the `get_limits` command test case to fail when either one of those MPTCP limits is non-zero.
* The `set_flags` command test case was performed after the `remove_addr`  test case.  This caused the kernel to return an invalid argument (`EINVAL`) error since the network address for which flags were to be set was no longer tracked by the kernel.
* The main event loop exited before all of the underlying generic netlink send and receive operations were completed, which then prevented the mptcpd command test cases from completing successfully.

Correct all of these issues.