### PR TITLE
src: Send remote address ID on subflow creation.

### DIFF
--- a/src/netlink_pm_upstream.c
+++ b/src/netlink_pm_upstream.c
@@ -344,7 +344,6 @@ static int upstream_add_subflow(struct mptcpd_pm *pm,
                                 struct sockaddr const *remote_addr,
                                 bool backup)
 {
-        (void) remote_id;
         (void) backup;
 
         /**
@@ -363,6 +362,7 @@ static int upstream_add_subflow(struct mptcpd_pm *pm,
                   Local address family
                   Local address
               (nested)
+                  Remote address ID
                   Remote address family
                   Remote address
                   Remote port
@@ -379,6 +379,7 @@ static int upstream_add_subflow(struct mptcpd_pm *pm,
 
         struct addr_info remote = {
                 .addr = remote_addr,
+                .id   = remote_id
         };
 
         size_t const payload_size =
@@ -386,9 +387,10 @@ static int upstream_add_subflow(struct mptcpd_pm *pm,
                 + MPTCPD_NLA_ALIGN(local_id)
                 + MPTCPD_NLA_ALIGN(sizeof(uint16_t))  // local family
                 + MPTCPD_NLA_ALIGN_ADDR(local_addr)
+                + MPTCPD_NLA_ALIGN(remote_id)
                 + MPTCPD_NLA_ALIGN(sizeof(uint16_t))  // remote family
                 + MPTCPD_NLA_ALIGN_ADDR(remote_addr)
-                + MPTCPD_NLA_ALIGN(sizeof(uint16_t));  // remote port
+                + MPTCPD_NLA_ALIGN(sizeof(uint16_t)); // remote port
 
         struct l_genl_msg *const msg =
                 l_genl_msg_new_sized(MPTCP_PM_CMD_SUBFLOW_CREATE,
@@ -449,7 +451,7 @@ static int upstream_remove_subflow(struct mptcpd_pm *pm,
                 + MPTCPD_NLA_ALIGN(sizeof(uint16_t))  // local port
                 + MPTCPD_NLA_ALIGN(sizeof(uint16_t))  // remote family
                 + MPTCPD_NLA_ALIGN_ADDR(remote_addr)
-                + MPTCPD_NLA_ALIGN(sizeof(uint16_t));  // remote port
+                + MPTCPD_NLA_ALIGN(sizeof(uint16_t)); // remote port
 
         struct l_genl_msg *const msg =
                 l_genl_msg_new_sized(MPTCP_PM_CMD_SUBFLOW_DESTROY,


### PR DESCRIPTION
When adding a new subflow send the user supplied remote address ID generic netlink attribute along with the command rather than ignoring it.  The upstream kernel currently doesn't parse the remote address ID, but it may do so in the future.