### PR TITLE
src: Fix genl command payload size calculations.

### DIFF
--- a/src/netlink_pm_upstream.c
+++ b/src/netlink_pm_upstream.c
@@ -386,6 +386,7 @@ static int upstream_add_subflow(struct mptcpd_pm *pm,
                 + MPTCPD_NLA_ALIGN(local_id)
                 + MPTCPD_NLA_ALIGN(sizeof(uint16_t))  // local family
                 + MPTCPD_NLA_ALIGN_ADDR(local_addr)
+                + MPTCPD_NLA_ALIGN_OPT(uint16_t)      // local port
                 + MPTCPD_NLA_ALIGN(sizeof(uint16_t))  // remote family
                 + MPTCPD_NLA_ALIGN_ADDR(remote_addr)
                 + MPTCPD_NLA_ALIGN(sizeof(uint16_t));  // remote port

--- a/src/netlink_pm_upstream.c
+++ b/src/netlink_pm_upstream.c
@@ -362,6 +362,7 @@ static int upstream_add_subflow(struct mptcpd_pm *pm,
                   Local address ID
                   Local address family
                   Local address
+                  Local port (optional, unused by kernel)
               (nested)
                   Remote address family
                   Remote address
@@ -381,15 +382,17 @@ static int upstream_add_subflow(struct mptcpd_pm *pm,
                 .addr = remote_addr,
         };
 
+        uint16_t const local_port  = mptcpd_get_port_number(local_addr);
+
         size_t const payload_size =
                 MPTCPD_NLA_ALIGN(token)
                 + MPTCPD_NLA_ALIGN(local_id)
-                + MPTCPD_NLA_ALIGN(sizeof(uint16_t))  // local family
+                + MPTCPD_NLA_ALIGN(uint16_t)          // local family
                 + MPTCPD_NLA_ALIGN_ADDR(local_addr)
-                + MPTCPD_NLA_ALIGN_OPT(uint16_t)      // local port
-                + MPTCPD_NLA_ALIGN(sizeof(uint16_t))  // remote family
+                + MPTCPD_NLA_ALIGN_OPT(local_port)
+                + MPTCPD_NLA_ALIGN(uint16_t)          // remote family
                 + MPTCPD_NLA_ALIGN_ADDR(remote_addr)
-                + MPTCPD_NLA_ALIGN(sizeof(uint16_t));  // remote port
+                + MPTCPD_NLA_ALIGN(uint16_t);         // remote port
 
         struct l_genl_msg *const msg =
                 l_genl_msg_new_sized(MPTCP_PM_CMD_SUBFLOW_CREATE,
@@ -445,12 +448,12 @@ static int upstream_remove_subflow(struct mptcpd_pm *pm,
 
         size_t const payload_size =
                 MPTCPD_NLA_ALIGN(token)
-                + MPTCPD_NLA_ALIGN(sizeof(uint16_t))  // local family
+                + MPTCPD_NLA_ALIGN(uint16_t)          // local family
                 + MPTCPD_NLA_ALIGN_ADDR(local_addr)
-                + MPTCPD_NLA_ALIGN(sizeof(uint16_t))  // local port
-                + MPTCPD_NLA_ALIGN(sizeof(uint16_t))  // remote family
+                + MPTCPD_NLA_ALIGN(uint16_t)          // local port
+                + MPTCPD_NLA_ALIGN(uint16_t)          // remote family
                 + MPTCPD_NLA_ALIGN_ADDR(remote_addr)
-                + MPTCPD_NLA_ALIGN(sizeof(uint16_t));  // remote port
+                + MPTCPD_NLA_ALIGN(uint16_t);         // remote port
 
         struct l_genl_msg *const msg =
                 l_genl_msg_new_sized(MPTCP_PM_CMD_SUBFLOW_DESTROY,
@@ -509,13 +512,13 @@ static int upstream_set_backup(struct mptcpd_pm *pm,
 
         size_t const payload_size =
                 MPTCPD_NLA_ALIGN(token)
-                + MPTCPD_NLA_ALIGN(sizeof(uint16_t))   // local family
+                + MPTCPD_NLA_ALIGN(uint16_t)           // local family
                 + MPTCPD_NLA_ALIGN_ADDR(local_addr)
-                + MPTCPD_NLA_ALIGN(sizeof(uint16_t))   // local port
-                + MPTCPD_NLA_ALIGN(sizeof(local.flags))
-                + MPTCPD_NLA_ALIGN(sizeof(uint16_t))   // remote family
+                + MPTCPD_NLA_ALIGN(uint16_t)           // local port
+                + MPTCPD_NLA_ALIGN(local.flags)
+                + MPTCPD_NLA_ALIGN(uint16_t)           // remote family
                 + MPTCPD_NLA_ALIGN_ADDR(remote_addr)
-                + MPTCPD_NLA_ALIGN(sizeof(uint16_t));  // remote port
+                + MPTCPD_NLA_ALIGN(uint16_t);          // remote port
 
         struct l_genl_msg *const msg =
                 l_genl_msg_new_sized(MPTCP_PM_CMD_SET_FLAGS,
@@ -1089,7 +1092,7 @@ static int upstream_set_flags(struct mptcpd_pm *pm,
 
         // Types chosen to match MPTCP genl API.
         size_t const payload_size =
-                MPTCPD_NLA_ALIGN(sizeof(uint16_t))  // family
+                MPTCPD_NLA_ALIGN(uint16_t)    // family
                 + MPTCPD_NLA_ALIGN_ADDR(addr)
                 + MPTCPD_NLA_ALIGN(flags);
 


### PR DESCRIPTION
Correct generic netlink command payload buffer size calculations by aligning against the size of the attribute (e.g. `sizeof(uint16_t)`) as  expected instead of size of the attribute size (e.g. `sizeof(sizeof(uint16_t))`).

Payload buffer sizes should now be smaller in some cases since netlink attributes are aligned on a 4 byte boundary.  For example, the underlying `NLA_ALIGN()` macro returns `4` when the type is `uint16_t`, i.e. `NLA_ALIGN(sizeof(uint16_t))`.  Previously, `8` was returned on 64 bit platforms since the `NLA_ALIGN()` call was incorrectly called as `NLA_ALIGN(sizeof(sizeof(uint16_t)))`, which boils downs to `NLA_ALIGN(size_t)`.
