### PR TITLE
tests: Skip listener manager test if no MPTCP.

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -106,6 +106,7 @@ test_id_manager_LDADD =				\
 test_listener_manager_SOURCES = test-listener-manager.c
 test_listener_manager_LDADD =			\
 	$(top_builddir)/lib/libmptcpd.la	\
+	$(builddir)/lib/libmptcpd_test.la	\
 	$(ELL_LIBS)				\
 	$(CODE_COVERAGE_LIBS)
 

--- a/tests/test-listener-manager.c
+++ b/tests/test-listener-manager.c
@@ -21,6 +21,7 @@
 #include <mptcpd/private/listener_manager.h>
 #include <mptcpd/listener_manager.h>
 
+#include "test-util.h"
 #include "test-plugin.h"  // For test sockaddrs
 
 #undef NDEBUG
@@ -151,6 +152,9 @@ static void test_destroy(void const *test_data)
 
 int main(int argc, char *argv[])
 {
+        // Skip this test if the kernel is not MPTCP capable.
+        tests_skip_if_no_mptcp();
+
         l_log_set_stderr();
         //l_debug_enable("*");
 

--- a/tests/test-listener-manager.c
+++ b/tests/test-listener-manager.c
@@ -22,7 +22,6 @@
 #include <mptcpd/listener_manager.h>
 
 #include "test-util.h"
-#include "test-plugin.h"  // For test sockaddrs
 
 #undef NDEBUG
 #include <assert.h>


### PR DESCRIPTION
The mptcpd listener manager will fail with a "_Protocol not supported_"  error when run against Linux kernels that do not support MPTCP.  Skip the test rather than fail with an error if MPTCP support isn't available.

Fixes #271.