### PR TITLE
Prepare for move to multipath-tcp/mptcpd

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -63,8 +63,7 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at the
 e-mail address for the Linux kernel MPTCP subsystem owner listed in
 the kernel
-[https://github.com/multipath-tcp/mptcp_net-next/blob/export/MAINTAINERS][`MAINTAINERS`]
-file.
+[https://www.kernel.org/doc/linux/MAINTAINERS][`MAINTAINERS`] file.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -63,7 +63,7 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at the
 e-mail address for the Linux kernel MPTCP subsystem owner listed in
 the kernel
-[https://www.kernel.org/doc/linux/MAINTAINERS][`MAINTAINERS`] file.
+[`MAINTAINERS`](https://www.kernel.org/doc/linux/MAINTAINERS) file.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,8 +60,11 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-mptcp-owner@lists.01.org.
+reported to the community leaders responsible for enforcement at the
+e-mail address for the Linux kernel MPTCP subsystem owner listed in
+the kernel
+[https://github.com/multipath-tcp/mptcp_net-next/blob/export/MAINTAINERS][`MAINTAINERS`]
+file.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,13 +31,13 @@ details on how to report security related bugs.
 
 #### General Bugs
 Please report all general bugs unrelated to security through a GitHub
-[issue](https://github.com/intel/mptcpd/issues), using the *Bug
-report* template.
+[issue](https://github.com/multipath-tcp/mptcpd/issues), using the
+*Bug report* template.
 
 ### Feature Requests
 As with bug report submission, feature requests may be created through
-a GitHub [issue](https://github.com/intel/mptcpd/issues), using the
-provided *Feature request* template.
+a GitHub [issue](https://github.com/multipath-tcp/mptcpd/issues),
+using the provided *Feature request* template.
 
 ### Submitting Changes
 Please ensure contributions do not introduce regressions, and conform

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <!-- SPDX-License-Identifier: BSD-3-Clause
      Copyright (c) 2017-2021, Intel Corporation -->
 
-[![C/C++ CI](https://github.com/intel/mptcpd/actions/workflows/ccpp.yml/badge.svg)](https://github.com/intel/mptcpd/actions/workflows/ccpp.yml)
-[![Coverage Status](https://coveralls.io/repos/github/intel/mptcpd/badge.svg?branch=master)](https://coveralls.io/github/intel/mptcpd?branch=master)
+[![C/C++ CI](https://github.com/multipath-tcp/mptcpd/actions/workflows/ccpp.yml/badge.svg)](https://github.com/multipath-tcp/mptcpd/actions/workflows/ccpp.yml)
+[![Coverage Status](https://coveralls.io/repos/github/multipath-tcp/mptcpd/badge.svg?branch=master)](https://coveralls.io/github/multipath-tcp/mptcpd?branch=master)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.0-4baaaa.svg)](CODE_OF_CONDUCT.md)
 
 # Multipath TCP Daemon

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,7 +24,7 @@ declined, etc.
 
 Please report all security related issues through the Linux kernel
 MPTCP subsystem owner listed in the kernel
-[https://www.kernel.org/doc/linux/MAINTAINERS][`MAINTAINERS`] file.
+[`MAINTAINERS`](https://www.kernel.org/doc/linux/MAINTAINERS) file.
 Include the following information:
   * Description of the security problem
   * Steps to reproduce

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,8 +22,10 @@ reported vulnerability, what to expect if the vulnerability is accepted or
 declined, etc.
 -->
 
-Please report all security related issues through the private e-mail
-mptcp-owner@lists.01.org.  Include the following information:
+Please report all security related issues through the Linux kernel
+MPTCP subsystem owner listed in the kernel
+[https://github.com/multipath-tcp/mptcp_net-next/blob/export/MAINTAINERS][`MAINTAINERS`]
+file.  Include the following information:
   * Description of the security problem
   * Steps to reproduce
   * Expected behavior

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,8 +24,8 @@ declined, etc.
 
 Please report all security related issues through the Linux kernel
 MPTCP subsystem owner listed in the kernel
-[https://github.com/multipath-tcp/mptcp_net-next/blob/export/MAINTAINERS][`MAINTAINERS`]
-file.  Include the following information:
+[https://www.kernel.org/doc/linux/MAINTAINERS][`MAINTAINERS`] file.
+Include the following information:
   * Description of the security problem
   * Steps to reproduce
   * Expected behavior

--- a/configure.ac
+++ b/configure.ac
@@ -9,7 +9,7 @@ AC_INIT([mptcpd],
         [0.11],
         [mptcp@lists.linux.dev],
         [],
-        [https://github.com/intel/mptcpd])
+        [https://github.com/multipath-tcp/mptcpd])
 
 # ---------------------------------------------------------------
 # Libtool Based Library Versioning

--- a/mptcpd.dox
+++ b/mptcpd.dox
@@ -17,7 +17,7 @@
  * subflows, etc.
  *
  * @see Additional higher level documentation is available in the
- *      [`mptcpd` Wiki](https://github.com/intel/mptcpd/wiki).
+ *      [`mptcpd` Wiki](https://github.com/multipath-tcp/mptcpd/wiki).
  */
 
 /*


### PR DESCRIPTION
A set of changes made in preparation for the move of `intel/mptcpd` repository to `multipath-tcp/mptcpd`.